### PR TITLE
feat: transaction functions populate the Anoma key-value store

### DIFF
--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -25,13 +25,6 @@ delete {A B} {{Ord A}} (k : A) : Map A B -> Map A B
       | just x := Set.delete x s |> Map.mkMap;
 
 -- Should be added to the `juvix-anoma-stdlib`
-
-type TxData (T : Type) :=
-  mkTxData {
-    tx : Transaction;
-    assignment : List (KeyValue.Assignment T)
-  };
-
 instance
 PublicKey-Show : Show PublicKey := mkShow \ {k := natToString (PublicKey.unPublicKey k)};
 

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -8,10 +8,19 @@ import Anoma open;
 import Data.Set as Set open using {Set};
 import Data.Map as Map open using {Map};
 
+union {A} {{Ord A}} (a b : Set A) : Set A := Set.fromList (Set.toList a ++ Set.toList b);
+
+-- TODO
+--intersection {A} {{Ord A}} (a b : Set A) : Set A := Set.empty;
+
+-- TODO
+--difference {A} {{Ord A}} (a b : Set A) : Set A := Set.empty;
+
 delete {A B} {{Ord A}} (k : A) : Map A B -> Map A B
-  | m@(Map.mkMap s) := case Set.lookupWith Map.key k s of
-    | nothing := m
-    | (just x) := Set.delete x s |> Map.mkMap;
+  | m@(Map.mkMap s) :=
+    case Set.lookupWith Map.key k s of
+      | nothing := m
+      | just x := Set.delete x s |> Map.mkMap;
 
 -- Should be added to the `juvix-anoma-stdlib`
 instance

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -10,11 +10,11 @@ import Data.Map as Map open using {Map};
 
 union {A} {{Ord A}} (a b : Set A) : Set A := Set.fromList (Set.toList a ++ Set.toList b);
 
--- TODO
---intersection {A} {{Ord A}} (a b : Set A) : Set A := Set.empty;
+intersection {A} {{Ord A}} (s1 : Set A) (s2 : Set A) : Set A :=
+  Set.toList s1 |> filter \ {x := Set.member? x s2} |> Set.fromList;
 
--- TODO
---difference {A} {{Ord A}} (a b : Set A) : Set A := Set.empty;
+difference {A} {{Ord A}} (s1 : Set A) (s2 : Set A) : Set A :=
+  Set.toList s1 |> filter \ {x := not (Set.member? x s2) } |> Set.fromList;
 
 delete {A B} {{Ord A}} (k : A) : Map A B -> Map A B
   | m@(Map.mkMap s) :=

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -239,4 +239,18 @@ compose (tx1 tx2 : Transaction) : Transaction :=
     preference := 0
   };
 
+emptyTx : Transaction := Transaction.mk@{
+      roots := [];
+      commitments := [];
+      nullifiers := [];
+      proofs := [];
+      complianceProofs := [];
+      delta := [];
+      extra := 0;
+      preference := 0
+    };
+
+composeAll (txs : List Transaction) : Transaction :=
+  for (acc := emptyTx) (tx in txs) {compose acc tx};
+
 rand : Nat := 0;

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -25,6 +25,13 @@ delete {A B} {{Ord A}} (k : A) : Map A B -> Map A B
       | just x := Set.delete x s |> Map.mkMap;
 
 -- Should be added to the `juvix-anoma-stdlib`
+
+type TxData (T : Type) :=
+  mkTxData {
+    tx : Transaction;
+    assignment : List (KeyValue.Assignment T)
+  };
+
 instance
 PublicKey-Show : Show PublicKey := mkShow \ {k := natToString (PublicKey.unPublicKey k)};
 

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -8,6 +8,11 @@ import Anoma open;
 import Data.Set as Set open using {Set};
 import Data.Map as Map open using {Map};
 
+delete {A B} {{Ord A}} (k : A) : Map A B -> Map A B
+  | m@(Map.mkMap s) := case Set.lookupWith Map.key k s of
+    | nothing := m
+    | (just x) := Set.delete x s |> Map.mkMap;
+
 -- Should be added to the `juvix-anoma-stdlib`
 instance
 PublicKey-Show : Show PublicKey := mkShow \ {k := natToString (PublicKey.unPublicKey k)};

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -223,6 +223,18 @@ mkTransaction
     preference := 0
   };
 
+emptyTx : Transaction :=
+  Transaction.mk@{
+    roots := [];
+    commitments := [];
+    nullifiers := [];
+    proofs := [];
+    complianceProofs := [];
+    delta := [];
+    extra := 0;
+    preference := 0
+  };
+
 compose (tx1 tx2 : Transaction) : Transaction :=
   Transaction.mk@{
     roots := Transaction.roots tx1 ++ Transaction.roots tx2;
@@ -238,17 +250,6 @@ compose (tx1 tx2 : Transaction) : Transaction :=
       in anomaEncode (Map.fromList (kvList1 ++ kvList2));
     preference := 0
   };
-
-emptyTx : Transaction := Transaction.mk@{
-      roots := [];
-      commitments := [];
-      nullifiers := [];
-      proofs := [];
-      complianceProofs := [];
-      delta := [];
-      extra := 0;
-      preference := 0
-    };
 
 composeAll (txs : List Transaction) : Transaction :=
   for (acc := emptyTx) (tx in txs) {compose acc tx};

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -14,7 +14,7 @@ intersection {A} {{Ord A}} (s1 : Set A) (s2 : Set A) : Set A :=
   Set.toList s1 |> filter \ {x := Set.member? x s2} |> Set.fromList;
 
 difference {A} {{Ord A}} (s1 : Set A) (s2 : Set A) : Set A :=
-  Set.toList s1 |> filter \ {x := not (Set.member? x s2) } |> Set.fromList;
+  Set.toList s1 |> filter \ {x := not (Set.member? x s2)} |> Set.fromList;
 
 delete {A B} {{Ord A}} (k : A) : Map A B -> Map A B
   | m@(Map.mkMap s) :=

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -8,6 +8,8 @@ import Anoma open;
 import Data.Set as Set open using {Set};
 import Data.Map as Map open using {Map};
 
+-- Should be added to the `juvix-containers`
+
 union {A} {{Ord A}} (a b : Set A) : Set A := Set.fromList (Set.toList a ++ Set.toList b);
 
 intersection {A} {{Ord A}} (s1 : Set A) (s2 : Set A) : Set A :=

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -57,7 +57,9 @@ mkTxWithExtraData
     nonEphConsumed := filter \ {r := not (isEphemeral r)} consumed;
     nonEphCreated := filter \ {r := not (isEphemeral r)} created;
 
+    -- Get the current ledger entries associated with all kinds and accounts involved in this transaction.
     ledger : LedgerMapping := getLedger (nonEphConsumed ++ nonEphCreated);
+    -- Replace the ;Set Commitment; in the mapping with one, where the consumed resource commitments have been removed.
     ledgerWithoutConsumed : LedgerMapping :=
       for (acc := ledger) (r in nonEphConsumed)
         {let
@@ -71,6 +73,7 @@ mkTxWithExtraData
                  | nothing := acc
                  | just inner :=
                    Map.insert kind (Map.insert account (Set.delete cm inner) outer) acc};
+    -- Replace the ;Set Commitment; in the mapping with one, where the created resource commitments have been added.
     ledgerWithoutConsumedWithCreated : LedgerMapping :=
       for (acc := ledgerWithoutConsumed) (r in nonEphCreated)
         {let
@@ -84,6 +87,7 @@ mkTxWithExtraData
                  | nothing := acc
                  | just inner :=
                    Map.insert kind (Map.insert account (Set.insert cm inner) outer) acc};
+    -- Create a ;List LedgerAssignment; to be processed by the Anoma node client.
     assignments : List LedgerAssignment :=
       for (outerAcc := []) (outerKey, outerVal in Map.toList ledgerWithoutConsumedWithCreated)
         {for (innerAcc := []) (innerKey, innerVal in Map.toList outerVal)
@@ -97,7 +101,7 @@ mkTxWithExtraData
                  value := innerVal
                }
                ]}};
-
+  -- Return the transaction object and the assignments.
   in Transaction.mk@{
       roots := [];
       commitments := map commitment created;

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -2,7 +2,7 @@ module Authorization.Message;
 
 import Stdlib.Prelude open;
 import Data.Map as Map open using {Map; empty};
-import Data.Set as Set open using {Set; insert; delete};
+import Data.Set as Set open using {Set; insert; delete; empty};
 import Anoma as MyAnoma open;
 import AnomaHelpers open;
 import Token.Indexing open;
@@ -127,3 +127,19 @@ mkTxWithExtraData
         created
       }
   };
+
+composeTxData (txData1 txData2 : TxData (Set Commitment)) : TxData (Set Commitment) :=
+  mkTxData@{
+    tx :=
+      compose@{
+        tx1 := TxData.tx txData1;
+        tx2 := TxData.tx txData2
+      };
+    assignment := TxData.assignment (txData1) ++ TxData.assignment (txData2)
+  };
+
+composeAllTxData (txDatas : List (TxData (Set Commitment))) : TxData (Set Commitment) :=
+  for (acc := mkTxData@{
+      tx := emptyTx;
+      assignment := []
+    }) (tx in txDatas) {composeTxData acc tx};

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -48,17 +48,14 @@ mkResourceRelationshipExtraData
       (mkResourceRelationshipExtraDataMapEntry nullifierKey mustBeConsumed mustBeCreated)
       origins);
 
-mkTxWithExtraData
-  (nk : PrivateKey)
-  (consumed : List Resource)
-  (created : List Resource)
-  : Pair Transaction (List LedgerAssignment) :=
+-- Creates a ;List LedgerAssignment; to be processed by the Anoma node client.
+prepareAssignments (consumed : List Resource) (created : List Resource) : List LedgerAssignment :=
   let
     nonEphConsumed := filter \ {r := not (isEphemeral r)} consumed;
     nonEphCreated := filter \ {r := not (isEphemeral r)} created;
 
     -- Get the current ledger entries associated with all kinds and accounts involved in this transaction.
-    ledger : LedgerMapping := getLedger (nonEphConsumed ++ nonEphCreated);
+    ledger : LedgerMapping := getLedgerMapping (nonEphConsumed ++ nonEphCreated);
     -- Replace the ;Set Commitment; in the mapping with one, where the consumed resource commitments have been removed.
     ledgerWithoutConsumed : LedgerMapping :=
       for (acc := ledger) (r in nonEphConsumed)
@@ -87,22 +84,25 @@ mkTxWithExtraData
                  | nothing := acc
                  | just inner :=
                    Map.insert kind (Map.insert account (Set.insert cm inner) outer) acc};
-    -- Create a ;List LedgerAssignment; to be processed by the Anoma node client.
-    assignments : List LedgerAssignment :=
-      for (outerAcc := []) (outerKey, outerVal in Map.toList ledgerWithoutConsumedWithCreated)
-        {for (innerAcc := []) (innerKey, innerVal in Map.toList outerVal)
-          {outerAcc
-            ++ [ KeyValue.assign@{
-                 key :=
-                   KeyValue.mkKey
-                     (map
-                       natToString
-                       [MyAnoma.Kind.unKind outerKey; PublicKey.unPublicKey innerKey]);
-                 value := innerVal
-               }
-               ]}};
-  -- Return the transaction object and the assignments.
-  in Transaction.mk@{
+  in for (outerAcc := []) (outerKey, outerVal in Map.toList ledgerWithoutConsumedWithCreated)
+       {for (innerAcc := []) (innerKey, innerVal in Map.toList outerVal)
+         {outerAcc
+           ++ [ KeyValue.assign@{
+                key :=
+                  KeyValue.mkKey
+                    (map
+                      natToString
+                      [MyAnoma.Kind.unKind outerKey; PublicKey.unPublicKey innerKey]);
+                value := innerVal
+              }
+              ]}};
+
+mkTxWithExtraData
+  (nk : PrivateKey)
+  (consumed : List Resource)
+  (created : List Resource)
+  : Pair Transaction (List LedgerAssignment) :=
+  Transaction.mk@{
       roots := [];
       commitments := map commitment created;
       nullifiers := map (r in consumed) nullifier r nk;
@@ -119,4 +119,7 @@ mkTxWithExtraData
           };
       preference := 0
     }
-    , assignments;
+    , prepareAssignments@{
+      consumed;
+      created
+    };

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -48,8 +48,8 @@ mkResourceRelationshipExtraData
       (mkResourceRelationshipExtraDataMapEntry nullifierKey mustBeConsumed mustBeCreated)
       origins);
 
--- Creates a ;List LedgerAssignment; to be processed by the Anoma node client.
-prepareAssignments (consumed : List Resource) (created : List Resource) : List LedgerAssignment :=
+-- Creates a ;List TokenAssignment; to be processed by the Anoma node client.
+prepareAssignments (consumed : List Resource) (created : List Resource) : List TokenAssignment :=
   let
     nonEphConsumed := filter \ {r := not (isEphemeral r)} consumed;
     nonEphCreated := filter \ {r := not (isEphemeral r)} created;
@@ -101,7 +101,7 @@ mkTxWithExtraData
   (nk : PrivateKey)
   (consumed : List Resource)
   (created : List Resource)
-  : Pair Transaction (List LedgerAssignment) :=
+  : Pair Transaction (List TokenAssignment) :=
   Transaction.mk@{
       roots := [];
       commitments := map commitment created;

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -101,25 +101,29 @@ mkTxWithExtraData
   (nk : PrivateKey)
   (consumed : List Resource)
   (created : List Resource)
-  : Pair Transaction (List TokenAssignment) :=
-  Transaction.mk@{
-      roots := [];
-      commitments := map commitment created;
-      nullifiers := map (r in consumed) nullifier r nk;
-      proofs := consumed ++ created;
-      complianceProofs := [];
-      delta := [];
-      extra :=
-        anomaEncode
-          mkResourceRelationshipExtraData@{
-            nullifierKey := nk;
-            origins := consumed;
-            mustBeConsumed := [];
-            mustBeCreated := created
-          };
-      preference := 0
-    }
-    , prepareAssignments@{
-      consumed;
-      created
-    };
+  : TxData (Set Commitment) :=
+  mkTxData@{
+    tx :=
+      Transaction.mk@{
+        roots := [];
+        commitments := map commitment created;
+        nullifiers := map (r in consumed) nullifier r nk;
+        proofs := consumed ++ created;
+        complianceProofs := [];
+        delta := [];
+        extra :=
+          anomaEncode
+            mkResourceRelationshipExtraData@{
+              nullifierKey := nk;
+              origins := consumed;
+              mustBeConsumed := [];
+              mustBeCreated := created
+            };
+        preference := 0
+      };
+    assignment :=
+      prepareAssignments@{
+        consumed;
+        created
+      }
+  };

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -56,8 +56,6 @@ mkTxWithExtraData
   let
     nonEphConsumed := filter \ {r := not (isEphemeral r)} consumed;
     nonEphCreated := filter \ {r := not (isEphemeral r)} created;
-    nonEphConsumedSet := Set.fromList (map commitment nonEphConsumed);
-    nonEphCreatedSet := Set.fromList (map commitment nonEphCreated);
 
     ledger : LedgerMapping := getLedger (nonEphConsumed ++ nonEphCreated);
     ledgerWithoutConsumed : LedgerMapping :=

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -2,10 +2,9 @@ module Authorization.Message;
 
 import Stdlib.Prelude open;
 import Data.Map as Map open using {Map; empty};
-import Data.Set as Set open using {Set; insert; delete; empty};
-import Anoma as MyAnoma open;
+import Data.Set as Set open using {Set; empty};
+import Anoma open;
 import AnomaHelpers open;
-import Token.Indexing open;
 
 -- TODO use Nullifier once we comply with v2 specs
 type ResourceRelationship :=
@@ -48,98 +47,22 @@ mkResourceRelationshipExtraData
       (mkResourceRelationshipExtraDataMapEntry nullifierKey mustBeConsumed mustBeCreated)
       origins);
 
--- Creates a ;List TokenAssignment; to be processed by the Anoma node client.
-prepareAssignments (consumed : List Resource) (created : List Resource) : List TokenAssignment :=
-  let
-    nonEphConsumed := filter \ {r := not (isEphemeral r)} consumed;
-    nonEphCreated := filter \ {r := not (isEphemeral r)} created;
-
-    -- Get the current ledger entries associated with all kinds and accounts involved in this transaction.
-    ledger : LedgerMapping := getLedgerMapping (nonEphConsumed ++ nonEphCreated);
-    -- Replace the ;Set Commitment; in the mapping with one, where the consumed resource commitments have been removed.
-    ledgerWithoutConsumed : LedgerMapping :=
-      for (acc := ledger) (r in nonEphConsumed)
-        {let
-          kind := anomaKind r;
-          account := Resource.npk r;
-          cm := commitment r;
-        in case Map.lookup kind acc of
-             | nothing := acc
-             | just outer :=
-               case Map.lookup account outer of
-                 | nothing := acc
-                 | just inner :=
-                   Map.insert kind (Map.insert account (Set.delete cm inner) outer) acc};
-    -- Replace the ;Set Commitment; in the mapping with one, where the created resource commitments have been added.
-    ledgerWithoutConsumedWithCreated : LedgerMapping :=
-      for (acc := ledgerWithoutConsumed) (r in nonEphCreated)
-        {let
-          kind := anomaKind r;
-          account := Resource.npk r;
-          cm := commitment r;
-        in case Map.lookup kind acc of
-             | nothing := acc
-             | just outer :=
-               case Map.lookup account outer of
-                 | nothing := acc
-                 | just inner :=
-                   Map.insert kind (Map.insert account (Set.insert cm inner) outer) acc};
-  in for (outerAcc := []) (outerKey, outerVal in Map.toList ledgerWithoutConsumedWithCreated)
-       {for (innerAcc := []) (innerKey, innerVal in Map.toList outerVal)
-         {outerAcc
-           ++ [ KeyValue.assign@{
-                key :=
-                  KeyValue.mkKey
-                    (map
-                      natToString
-                      [MyAnoma.Kind.unKind outerKey; PublicKey.unPublicKey innerKey]);
-                value := innerVal
-              }
-              ]}};
-
 mkTxWithExtraData
-  (nk : PrivateKey)
-  (consumed : List Resource)
-  (created : List Resource)
-  : TxData (Set Commitment) :=
-  mkTxData@{
-    tx :=
-      Transaction.mk@{
-        roots := [];
-        commitments := map commitment created;
-        nullifiers := map (r in consumed) nullifier r nk;
-        proofs := consumed ++ created;
-        complianceProofs := [];
-        delta := [];
-        extra :=
-          anomaEncode
-            mkResourceRelationshipExtraData@{
-              nullifierKey := nk;
-              origins := consumed;
-              mustBeConsumed := [];
-              mustBeCreated := created
-            };
-        preference := 0
-      };
-    assignment :=
-      prepareAssignments@{
-        consumed;
-        created
-      }
+  (nk : PrivateKey) (consumed : List Resource) (created : List Resource) : Transaction :=
+  Transaction.mk@{
+    roots := [];
+    commitments := map commitment created;
+    nullifiers := map (r in consumed) nullifier r nk;
+    proofs := consumed ++ created;
+    complianceProofs := [];
+    delta := [];
+    extra :=
+      anomaEncode
+        mkResourceRelationshipExtraData@{
+          nullifierKey := nk;
+          origins := consumed;
+          mustBeConsumed := [];
+          mustBeCreated := created
+        };
+    preference := 0
   };
-
-composeTxData (txData1 txData2 : TxData (Set Commitment)) : TxData (Set Commitment) :=
-  mkTxData@{
-    tx :=
-      compose@{
-        tx1 := TxData.tx txData1;
-        tx2 := TxData.tx txData2
-      };
-    assignment := TxData.assignment (txData1) ++ TxData.assignment (txData2)
-  };
-
-composeAllTxData (txDatas : List (TxData (Set Commitment))) : TxData (Set Commitment) :=
-  for (acc := mkTxData@{
-      tx := emptyTx;
-      assignment := []
-    }) (tx in txDatas) {composeTxData acc tx};

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -48,7 +48,7 @@ mkResourceRelationshipExtraData
       (mkResourceRelationshipExtraDataMapEntry nullifierKey mustBeConsumed mustBeCreated)
       origins);
 
-mkTxWithExtraData
+mkTxWithExtraDataOld
   (nk : PrivateKey) (consumed : List Resource) (created : List Resource) : Transaction :=
   Transaction.mk@{
     roots := [];
@@ -68,8 +68,11 @@ mkTxWithExtraData
     preference := 0
   };
 
-mkTxWithExtraData2
-  (nk : PrivateKey) (consumed : List Resource) (created : List Resource) : Transaction :=
+mkTxWithExtraData
+  (nk : PrivateKey)
+  (consumed : List Resource)
+  (created : List Resource)
+  : Pair Transaction (List LedgerAssignment) :=
   let
     nonEphConsumed := filter \ {r := not (isEphemeral r)} consumed;
     nonEphCreated := filter \ {r := not (isEphemeral r)} created;
@@ -77,7 +80,7 @@ mkTxWithExtraData2
     nonEphCreatedSet := Set.fromList (map commitment nonEphCreated);
 
     ledger : LedgerMapping := getLedger (nonEphConsumed ++ nonEphCreated);
-    ledgerWithoutConsumed :=
+    ledgerWithoutConsumed : LedgerMapping :=
       for (acc := ledger) (r in nonEphConsumed)
         {let
           kind := anomaKind r;
@@ -90,7 +93,7 @@ mkTxWithExtraData2
                  | nothing := acc
                  | just inner :=
                    Map.insert kind (Map.insert account (Set.delete cm inner) outer) acc};
-    ledgerWithoutConsumedWithCreated :=
+    ledgerWithoutConsumedWithCreated : LedgerMapping :=
       for (acc := ledgerWithoutConsumed) (r in nonEphCreated)
         {let
           kind := anomaKind r;
@@ -103,21 +106,36 @@ mkTxWithExtraData2
                  | nothing := acc
                  | just inner :=
                    Map.insert kind (Map.insert account (Set.insert cm inner) outer) acc};
-  -- TODO create ledger assignments from mapping
+    -- create ledger assignments from mapping
+    assignments : List LedgerAssignment :=
+      for (outerAcc := []) (outerKey, outerVal in Map.toList ledgerWithoutConsumedWithCreated)
+        {for (innerAcc := []) (innerKey, innerVal in Map.toList outerVal)
+          {outerAcc
+            ++ [ KeyValue.assign@{
+                 key :=
+                   KeyValue.mkKey
+                     (map
+                       natToString
+                       [Kind.unKind outerKey; PublicKey.unPublicKey innerKey]);
+                 value := innerVal
+               }
+               ]}};
+
   in Transaction.mk@{
-    roots := [];
-    commitments := map commitment created;
-    nullifiers := map (r in consumed) nullifier r nk;
-    proofs := consumed ++ created;
-    complianceProofs := [];
-    delta := [];
-    extra :=
-      anomaEncode
-        mkResourceRelationshipExtraData@{
-          nullifierKey := nk;
-          origins := consumed;
-          mustBeConsumed := [];
-          mustBeCreated := created
-        };
-    preference := 0
-  };
+      roots := [];
+      commitments := map commitment created;
+      nullifiers := map (r in consumed) nullifier r nk;
+      proofs := consumed ++ created;
+      complianceProofs := [];
+      delta := [];
+      extra :=
+        anomaEncode
+          mkResourceRelationshipExtraData@{
+            nullifierKey := nk;
+            origins := consumed;
+            mustBeConsumed := [];
+            mustBeCreated := created
+          };
+      preference := 0
+    }
+    , assignments;

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -2,7 +2,7 @@ module Authorization.Message;
 
 import Stdlib.Prelude open;
 import Data.Map as Map open using {Map; empty};
-import Data.Set as Set open using {Set; insert};
+import Data.Set as Set open using {Set; insert; delete};
 import Anoma open;
 import AnomaHelpers open;
 import Token.Indexing open;
@@ -71,17 +71,39 @@ mkTxWithExtraData
 mkTxWithExtraData2
   (nk : PrivateKey) (consumed : List Resource) (created : List Resource) : Transaction :=
   let
-    kinds : Set Kind := for (acc := Set.empty) (r in consumed) {insert (anomaKind r) acc};
-    accounts : Set PublicKey := for (acc := Set.empty) (r in consumed) {insert (Resource.npk r) acc};
-    -- anomaGet all relevant commitment sets
-    ledger : Map Kind (Map PublicKey (Set Commitment)) := 
-    for (outerMap := Map.empty) (kind in kinds) {
-      insert kind (
-        for (innerMap := Map.empty) (account in accounts) {
-          insert account ledgerEntries@{kind; account} innerMap
-        }
-      ) outerMap
-    };
+    nonEphConsumed := filter \ {r := not (isEphemeral r)} consumed;
+    nonEphCreated := filter \ {r := not (isEphemeral r)} created;
+    nonEphConsumedSet := Set.fromList (map commitment nonEphConsumed);
+    nonEphCreatedSet := Set.fromList (map commitment nonEphCreated);
+
+    ledger : LedgerMapping := getLedger (nonEphConsumed ++ nonEphCreated);
+    ledgerWithoutConsumed :=
+      for (acc := ledger) (r in nonEphConsumed)
+        {let
+          kind := anomaKind r;
+          account := Resource.npk r;
+          cm := commitment r;
+        in case Map.lookup kind acc of
+             | nothing := acc
+             | just outer :=
+               case Map.lookup account outer of
+                 | nothing := acc
+                 | just inner :=
+                   Map.insert kind (Map.insert account (Set.delete cm inner) outer) acc};
+    ledgerWithoutConsumedWithCreated :=
+      for (acc := ledgerWithoutConsumed) (r in nonEphCreated)
+        {let
+          kind := anomaKind r;
+          account := Resource.npk r;
+          cm := commitment r;
+        in case Map.lookup kind acc of
+             | nothing := acc
+             | just outer :=
+               case Map.lookup account outer of
+                 | nothing := acc
+                 | just inner :=
+                   Map.insert kind (Map.insert account (Set.insert cm inner) outer) acc};
+  -- TODO create ledger assignments from mapping
   in Transaction.mk@{
     roots := [];
     commitments := map commitment created;

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -1,10 +1,11 @@
 module Authorization.Message;
 
 import Stdlib.Prelude open;
-import Data.Map as Map open using {Map};
-import Data.Set as Set open using {Set};
+import Data.Map as Map open using {Map; empty};
+import Data.Set as Set open using {Set; insert};
 import Anoma open;
 import AnomaHelpers open;
+import Token.Indexing open;
 
 -- TODO use Nullifier once we comply with v2 specs
 type ResourceRelationship :=
@@ -50,6 +51,38 @@ mkResourceRelationshipExtraData
 mkTxWithExtraData
   (nk : PrivateKey) (consumed : List Resource) (created : List Resource) : Transaction :=
   Transaction.mk@{
+    roots := [];
+    commitments := map commitment created;
+    nullifiers := map (r in consumed) nullifier r nk;
+    proofs := consumed ++ created;
+    complianceProofs := [];
+    delta := [];
+    extra :=
+      anomaEncode
+        mkResourceRelationshipExtraData@{
+          nullifierKey := nk;
+          origins := consumed;
+          mustBeConsumed := [];
+          mustBeCreated := created
+        };
+    preference := 0
+  };
+
+mkTxWithExtraData2
+  (nk : PrivateKey) (consumed : List Resource) (created : List Resource) : Transaction :=
+  let
+    kinds : Set Kind := for (acc := Set.empty) (r in consumed) {insert (anomaKind r) acc};
+    accounts : Set PublicKey := for (acc := Set.empty) (r in consumed) {insert (Resource.npk r) acc};
+    -- anomaGet all relevant commitment sets
+    ledger : Map Kind (Map PublicKey (Set Commitment)) := 
+    for (outerMap := Map.empty) (kind in kinds) {
+      insert kind (
+        for (innerMap := Map.empty) (account in accounts) {
+          insert account ledgerEntries@{kind; account} innerMap
+        }
+      ) outerMap
+    };
+  in Transaction.mk@{
     roots := [];
     commitments := map commitment created;
     nullifiers := map (r in consumed) nullifier r nk;

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -48,26 +48,6 @@ mkResourceRelationshipExtraData
       (mkResourceRelationshipExtraDataMapEntry nullifierKey mustBeConsumed mustBeCreated)
       origins);
 
-mkTxWithExtraDataOld
-  (nk : PrivateKey) (consumed : List Resource) (created : List Resource) : Transaction :=
-  Transaction.mk@{
-    roots := [];
-    commitments := map commitment created;
-    nullifiers := map (r in consumed) nullifier r nk;
-    proofs := consumed ++ created;
-    complianceProofs := [];
-    delta := [];
-    extra :=
-      anomaEncode
-        mkResourceRelationshipExtraData@{
-          nullifierKey := nk;
-          origins := consumed;
-          mustBeConsumed := [];
-          mustBeCreated := created
-        };
-    preference := 0
-  };
-
 mkTxWithExtraData
   (nk : PrivateKey)
   (consumed : List Resource)
@@ -106,7 +86,6 @@ mkTxWithExtraData
                  | nothing := acc
                  | just inner :=
                    Map.insert kind (Map.insert account (Set.insert cm inner) outer) acc};
-    -- create ledger assignments from mapping
     assignments : List LedgerAssignment :=
       for (outerAcc := []) (outerKey, outerVal in Map.toList ledgerWithoutConsumedWithCreated)
         {for (innerAcc := []) (innerKey, innerVal in Map.toList outerVal)

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -3,7 +3,7 @@ module Authorization.Message;
 import Stdlib.Prelude open;
 import Data.Map as Map open using {Map; empty};
 import Data.Set as Set open using {Set; insert; delete};
-import Anoma open;
+import Anoma as MyAnoma open;
 import AnomaHelpers open;
 import Token.Indexing open;
 
@@ -116,7 +116,7 @@ mkTxWithExtraData
                    KeyValue.mkKey
                      (map
                        natToString
-                       [Kind.unKind outerKey; PublicKey.unPublicKey innerKey]);
+                       [MyAnoma.Kind.unKind outerKey; PublicKey.unPublicKey innerKey]);
                  value := innerVal
                }
                ]}};

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -6,7 +6,7 @@ import Data.Map as Map open using {Map};
 import Anoma as MyAnoma open;
 import AnomaHelpers open;
 
-LedgerAssignment : Type := KeyValue.Assignment (Set Commitment);
+TokenAssignment : Type := KeyValue.Assignment (Set Commitment);
 
 ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
   KeyValue.mkKey (map natToString [MyAnoma.Kind.unKind kind; PublicKey.unPublicKey account]);

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -23,7 +23,7 @@ getAccounts (rs : List Resource) : Set PublicKey :=
 LedgerMapping : Type := Map Kind (Map PublicKey (Set Commitment));
 
 -- This relies on sets having each entry only once, so that we don't overwrite map entries.
-getLedger (rs : List Resource) : LedgerMapping :=
+getLedgerMapping (rs : List Resource) : LedgerMapping :=
   let
     kinds : List Kind := Set.toList (getKinds rs);
     accounts : List PublicKey := Set.toList (getAccounts rs);

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -6,6 +6,8 @@ import Data.Map as Map open using {Map};
 import Anoma as MyAnoma open;
 import AnomaHelpers open;
 
+LedgerAssignment : Type := KeyValue.Assignment (Set Commitment);
+
 ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
   KeyValue.mkKey (map natToString [MyAnoma.Kind.unKind kind; PublicKey.unPublicKey account]);
 
@@ -36,49 +38,3 @@ getLedger (rs : List Resource) : LedgerMapping :=
              }
              innerMap})
          outerMap};
-
-addCommitments (kind : Kind) (account : PublicKey) (cms : List Commitment) : Set Commitment :=
-  for (entries := ledgerEntries kind account) (cm in cms) {Set.insert cm entries};
-
-removeCommitments (kind : Kind) (account : PublicKey) (cms : List Commitment) : Set Commitment :=
-  for (entries := ledgerEntries kind account) (cm in cms) {Set.delete cm entries};
-
-instance
-Key-Eq : Eq KeyValue.Key :=
-  mkEq@{
-    eq (l1 l2 : KeyValue.Key) : Bool := anomaEncode l1 == anomaEncode l2
-  };
-
-LedgerAssignment : Type := KeyValue.Assignment (Set Commitment);
-
---- TODO delete
-combineAssignments (a b : LedgerAssignment) : List LedgerAssignment :=
-  let
-    keyA := KeyValue.Assignment.key a;
-    keyB := KeyValue.Assignment.key b;
-  in case keyA == keyB of
-       | false := [a; b]
-       | true :=
-         [ KeyValue.assign@{
-           key := keyA;
-           value := union (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
-         }
-         ];
-
-addToLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : LedgerAssignment :=
-  KeyValue.assign@{
-    key := ledgerKey kind account;
-    value := for (entries := ledgerEntries kind account) (cm in cms) {Set.insert cm entries}
-  };
-
-removeFromLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : LedgerAssignment :=
-  KeyValue.assign@{
-    key := ledgerKey kind account;
-    value := for (entries := ledgerEntries kind account) (cm in cms) {Set.delete cm entries}
-  };
-
-combineAssignments2 (a b : LedgerAssignment) : LedgerAssignment :=
-  KeyValue.assign@{
-    key := KeyValue.Assignment.key a;
-    value := union (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
-  };

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -1,7 +1,8 @@
 module Token.Indexing;
 
 import Stdlib.Prelude open;
-import Data.Set as Set open using {Set; member?; insert; delete; empty};
+import Data.Set as Set open using {Set; insert; delete};
+import Data.Map as Map open using {Map};
 import Anoma open;
 
 ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
@@ -10,13 +11,44 @@ ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
 ledgerEntries (kind : Kind) (account : PublicKey) : Set Commitment :=
   anomaGet (ledgerKey kind account);
 
+getKinds (rs : List Resource) : Set Kind :=
+  for (acc := Set.empty) (r in rs) {insert (anomaKind r) acc};
+
+getAccounts (rs : List Resource) : Set PublicKey :=
+  for (acc := Set.empty) (r in rs) {insert (Resource.npk r) acc};
+
+LedgerMapping : Type := Map Kind (Map PublicKey (Set Commitment));
+
+getLedger (rs : List Resource) : LedgerMapping :=
+  let
+    kinds : List Kind := Set.toList (getKinds rs);
+    accounts : List PublicKey := Set.toList (getAccounts rs);
+  in for (outerMap := Map.empty) (kind in kinds)
+       {Map.insert
+         kind
+         (for (innerMap := Map.empty) (account in accounts)
+           {Map.insert
+             account
+             ledgerEntries@{
+               kind;
+               account
+             }
+             innerMap})
+         outerMap};
+
 addCommitments (kind : Kind) (account : PublicKey) (cms : List Commitment) : Set Commitment :=
-  for (entries := ledgerEntries kind account) (cm in cms) {insert cm entries};
+  for (entries := ledgerEntries kind account) (cm in cms) {Set.insert cm entries};
 
 removeCommitments (kind : Kind) (account : PublicKey) (cms : List Commitment) : Set Commitment :=
   for (entries := ledgerEntries kind account) (cm in cms) {delete cm entries};
 
-combine {A} {{Ord A}} (a b : Set A) : Set A := Set.fromList (Set.toList a ++ Set.toList b);
+union {A} {{Ord A}} (a b : Set A) : Set A := Set.fromList (Set.toList a ++ Set.toList b);
+
+-- TODO
+intersection {A} {{Ord A}} (a b : Set A) : Set A := Set.empty;
+
+-- TODO
+difference {A} {{Ord A}} (a b : Set A) : Set A := Set.empty;
 
 instance
 Key-Eq : Eq KeyValue.Key :=
@@ -25,38 +57,6 @@ Key-Eq : Eq KeyValue.Key :=
   };
 
 LedgerAssignment : Type := KeyValue.Assignment (Set Commitment);
-
-type Operation :=
-  | Add
-  | Remove;
-
-ledgerAssign
-  (kind : Kind)
-  (account : PublicKey)
-  (operation : Operation)
-  (cms : List Commitment)
-  : LedgerAssignment :=
-  KeyValue.assign@{
-    key :=
-      ledgerKey@{
-        kind;
-        account
-      };
-    value :=
-      case operation of
-        | Add :=
-          addCommitments@{
-            kind;
-            account;
-            cms
-          }
-        | Remove :=
-          removeCommitments@{
-            kind;
-            account;
-            cms
-          }
-  };
 
 --- TODO delete
 combineAssignments (a b : LedgerAssignment) : List LedgerAssignment :=
@@ -68,14 +68,14 @@ combineAssignments (a b : LedgerAssignment) : List LedgerAssignment :=
        | true :=
          [ KeyValue.assign@{
            key := keyA;
-           value := combine (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
+           value := union (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
          }
          ];
 
 addToLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : LedgerAssignment :=
   KeyValue.assign@{
     key := ledgerKey kind account;
-    value := for (entries := ledgerEntries kind account) (cm in cms) {insert cm entries}
+    value := for (entries := ledgerEntries kind account) (cm in cms) {Set.insert cm entries}
   };
 
 removeFromLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : LedgerAssignment :=
@@ -87,5 +87,5 @@ removeFromLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : L
 combineAssignments2 (a b : LedgerAssignment) : LedgerAssignment :=
   KeyValue.assign@{
     key := KeyValue.Assignment.key a;
-    value := combine (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
+    value := union (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
   };

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -1,0 +1,39 @@
+module Token.Indexing;
+
+import Stdlib.Prelude open;
+import Data.Set as Set open using {Set; member?; insert; delete};
+import Anoma open;
+
+ownedCommitmentsKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
+  KeyValue.mkKey (map natToString [Kind.unKind kind; PublicKey.unPublicKey account]);
+
+getOwnedCommitments (kind : Kind) (account : PublicKey) : Set Commitment :=
+  anomaGet (ownedCommitmentsKey kind account);
+
+addOwnedCommitment (kind : Kind) (account : PublicKey) (cm : Commitment) : Set Commitment :=
+  insert cm (getOwnedCommitments kind account);
+
+removeOwnedCommitment (kind : Kind) (account : PublicKey) (cm : Commitment) : Set Commitment :=
+  delete cm (getOwnedCommitments kind account);
+
+combine (a b : Set Commitment) : Set Commitment := Set.fromList (Set.toList a ++ Set.toList b);
+
+instance
+Key-Eq : Eq KeyValue.Key :=
+  mkEq@{
+    eq (l1 l2 : KeyValue.Key) : Bool := anomaEncode l1 == anomaEncode l2
+  };
+
+combineAssignments
+  (a b : KeyValue.Assignment (Set Commitment)) : List (KeyValue.Assignment (Set Commitment)) :=
+  let
+    keyA := KeyValue.Assignment.key a;
+    keyB := KeyValue.Assignment.key b;
+  in case keyA == keyB of
+       | true :=
+         [ KeyValue.assign@{
+           key := keyA;
+           value := combine (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
+         }
+         ]
+       | false := [a; b];

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -22,6 +22,7 @@ getAccounts (rs : List Resource) : Set PublicKey :=
 
 LedgerMapping : Type := Map Kind (Map PublicKey (Set Commitment));
 
+-- This relies on sets having each entry only once, so that we don't overwrite map entries.
 getLedger (rs : List Resource) : LedgerMapping :=
   let
     kinds : List Kind := Set.toList (getKinds rs);

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -3,11 +3,11 @@ module Token.Indexing;
 import Stdlib.Prelude open;
 import Data.Set as Set open using {Set; insert; delete};
 import Data.Map as Map open using {Map};
-import Anoma open;
+import Anoma as MyAnoma open;
 import AnomaHelpers open;
 
 ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
-  KeyValue.mkKey (map natToString [Kind.unKind kind; PublicKey.unPublicKey account]);
+  KeyValue.mkKey (map natToString [MyAnoma.Kind.unKind kind; PublicKey.unPublicKey account]);
 
 ledgerEntries (kind : Kind) (account : PublicKey) : Set Commitment :=
   anomaGet (ledgerKey kind account);
@@ -74,7 +74,7 @@ addToLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : Ledger
 removeFromLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : LedgerAssignment :=
   KeyValue.assign@{
     key := ledgerKey kind account;
-    value := for (entries := ledgerEntries kind account) (cm in cms) {delete cm entries}
+    value := for (entries := ledgerEntries kind account) (cm in cms) {Set.delete cm entries}
   };
 
 combineAssignments2 (a b : LedgerAssignment) : LedgerAssignment :=

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -4,19 +4,19 @@ import Stdlib.Prelude open;
 import Data.Set as Set open using {Set; member?; insert; delete};
 import Anoma open;
 
-ownedCommitmentsKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
+ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
   KeyValue.mkKey (map natToString [Kind.unKind kind; PublicKey.unPublicKey account]);
 
-getOwnedCommitments (kind : Kind) (account : PublicKey) : Set Commitment :=
-  anomaGet (ownedCommitmentsKey kind account);
+ledgerEntries (kind : Kind) (account : PublicKey) : Set Commitment :=
+  anomaGet (ledgerKey kind account);
 
-addOwnedCommitment (kind : Kind) (account : PublicKey) (cm : Commitment) : Set Commitment :=
-  insert cm (getOwnedCommitments kind account);
+addCommitment (kind : Kind) (account : PublicKey) (cm : Commitment) : Set Commitment :=
+  insert cm (ledgerEntries kind account);
 
-removeOwnedCommitment (kind : Kind) (account : PublicKey) (cm : Commitment) : Set Commitment :=
-  delete cm (getOwnedCommitments kind account);
+removeCommitment (kind : Kind) (account : PublicKey) (cm : Commitment) : Set Commitment :=
+  delete cm (ledgerEntries kind account);
 
-combine (a b : Set Commitment) : Set Commitment := Set.fromList (Set.toList a ++ Set.toList b);
+combine {A} {{Ord A}} (a b : Set A) : Set A := Set.fromList (Set.toList a ++ Set.toList b);
 
 instance
 Key-Eq : Eq KeyValue.Key :=
@@ -24,8 +24,40 @@ Key-Eq : Eq KeyValue.Key :=
     eq (l1 l2 : KeyValue.Key) : Bool := anomaEncode l1 == anomaEncode l2
   };
 
-combineAssignments
-  (a b : KeyValue.Assignment (Set Commitment)) : List (KeyValue.Assignment (Set Commitment)) :=
+LedgerAssignment : Type := KeyValue.Assignment (Set Commitment);
+
+type Operation :=
+  | Add
+  | Remove;
+
+ledgerAssign
+  (account : PublicKey) (resource : Resource) (operation : Operation) : LedgerAssignment :=
+  let
+    kind := anomaKind resource;
+    cm := commitment resource;
+  in KeyValue.assign@{
+    key :=
+      ledgerKey@{
+        kind;
+        account
+      };
+    value :=
+      case operation of
+        | Add :=
+          addCommitment@{
+            kind;
+            account;
+            cm
+          }
+        | Remove :=
+          removeCommitment@{
+            kind;
+            account;
+            cm
+          }
+  };
+
+combineAssignments (a b : LedgerAssignment) : List LedgerAssignment :=
   let
     keyA := KeyValue.Assignment.key a;
     keyB := KeyValue.Assignment.key b;

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -4,6 +4,7 @@ import Stdlib.Prelude open;
 import Data.Set as Set open using {Set; insert; delete};
 import Data.Map as Map open using {Map};
 import Anoma open;
+import AnomaHelpers open;
 
 ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
   KeyValue.mkKey (map natToString [Kind.unKind kind; PublicKey.unPublicKey account]);
@@ -40,15 +41,7 @@ addCommitments (kind : Kind) (account : PublicKey) (cms : List Commitment) : Set
   for (entries := ledgerEntries kind account) (cm in cms) {Set.insert cm entries};
 
 removeCommitments (kind : Kind) (account : PublicKey) (cms : List Commitment) : Set Commitment :=
-  for (entries := ledgerEntries kind account) (cm in cms) {delete cm entries};
-
-union {A} {{Ord A}} (a b : Set A) : Set A := Set.fromList (Set.toList a ++ Set.toList b);
-
--- TODO
-intersection {A} {{Ord A}} (a b : Set A) : Set A := Set.empty;
-
--- TODO
-difference {A} {{Ord A}} (a b : Set A) : Set A := Set.empty;
+  for (entries := ledgerEntries kind account) (cm in cms) {Set.delete cm entries};
 
 instance
 Key-Eq : Eq KeyValue.Key :=

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -1,7 +1,7 @@
 module Token.Indexing;
 
 import Stdlib.Prelude open;
-import Data.Set as Set open using {Set; member?; insert; delete};
+import Data.Set as Set open using {Set; member?; insert; delete; empty};
 import Anoma open;
 
 ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
@@ -10,11 +10,11 @@ ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
 ledgerEntries (kind : Kind) (account : PublicKey) : Set Commitment :=
   anomaGet (ledgerKey kind account);
 
-addCommitment (kind : Kind) (account : PublicKey) (cm : Commitment) : Set Commitment :=
-  insert cm (ledgerEntries kind account);
+addCommitments (kind : Kind) (account : PublicKey) (cms : List Commitment) : Set Commitment :=
+  for (entries := ledgerEntries kind account) (cm in cms) {insert cm entries};
 
-removeCommitment (kind : Kind) (account : PublicKey) (cm : Commitment) : Set Commitment :=
-  delete cm (ledgerEntries kind account);
+removeCommitments (kind : Kind) (account : PublicKey) (cms : List Commitment) : Set Commitment :=
+  for (entries := ledgerEntries kind account) (cm in cms) {delete cm entries};
 
 combine {A} {{Ord A}} (a b : Set A) : Set A := Set.fromList (Set.toList a ++ Set.toList b);
 
@@ -31,11 +31,12 @@ type Operation :=
   | Remove;
 
 ledgerAssign
-  (account : PublicKey) (resource : Resource) (operation : Operation) : LedgerAssignment :=
-  let
-    kind := anomaKind resource;
-    cm := commitment resource;
-  in KeyValue.assign@{
+  (kind : Kind)
+  (account : PublicKey)
+  (operation : Operation)
+  (cms : List Commitment)
+  : LedgerAssignment :=
+  KeyValue.assign@{
     key :=
       ledgerKey@{
         kind;
@@ -44,28 +45,47 @@ ledgerAssign
     value :=
       case operation of
         | Add :=
-          addCommitment@{
+          addCommitments@{
             kind;
             account;
-            cm
+            cms
           }
         | Remove :=
-          removeCommitment@{
+          removeCommitments@{
             kind;
             account;
-            cm
+            cms
           }
   };
 
+--- TODO delete
 combineAssignments (a b : LedgerAssignment) : List LedgerAssignment :=
   let
     keyA := KeyValue.Assignment.key a;
     keyB := KeyValue.Assignment.key b;
   in case keyA == keyB of
+       | false := [a; b]
        | true :=
          [ KeyValue.assign@{
            key := keyA;
            value := combine (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
          }
-         ]
-       | false := [a; b];
+         ];
+
+addToLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : LedgerAssignment :=
+  KeyValue.assign@{
+    key := ledgerKey kind account;
+    value := for (entries := ledgerEntries kind account) (cm in cms) {insert cm entries}
+  };
+
+removeFromLedger (kind : Kind) (account : PublicKey) (cms : List Commitment) : LedgerAssignment :=
+  KeyValue.assign@{
+    key := ledgerKey kind account;
+    value := for (entries := ledgerEntries kind account) (cm in cms) {delete cm entries}
+  };
+
+combineAssignments2 (a b : LedgerAssignment) : LedgerAssignment :=
+  KeyValue.assign@{
+    key := KeyValue.Assignment.key a;
+    value := combine (KeyValue.Assignment.value a) (KeyValue.Assignment.value b)
+  };

--- a/Token/Indexing.juvix
+++ b/Token/Indexing.juvix
@@ -6,8 +6,6 @@ import Data.Map as Map open using {Map};
 import Anoma as MyAnoma open;
 import AnomaHelpers open;
 
-TokenAssignment : Type := KeyValue.Assignment (Set Commitment);
-
 ledgerKey (kind : Kind) (account : PublicKey) : KeyValue.Key :=
   KeyValue.mkKey (map natToString [MyAnoma.Kind.unKind kind; PublicKey.unPublicKey account]);
 
@@ -39,3 +37,53 @@ getLedgerMapping (rs : List Resource) : LedgerMapping :=
              }
              innerMap})
          outerMap};
+
+-- Creates a ;List TokenAssignment; to be processed by the Anoma node client.
+prepareAssignments (tx : Transaction) : List (KeyValue.Assignment (Set Commitment)) :=
+  let
+    part : ResourcePartition := MyAnoma.partitionResources tx;
+    nonEphConsumed := filter \ {r := not (isEphemeral r)} (ResourcePartition.consumed part);
+    nonEphCreated := filter \ {r := not (isEphemeral r)} (ResourcePartition.created part);
+
+    -- Get the current ledger entries associated with all kinds and accounts involved in this transaction.
+    ledger : LedgerMapping := getLedgerMapping (nonEphConsumed ++ nonEphCreated);
+    -- Replace the ;Set Commitment; in the mapping with one, where the consumed resource commitments have been removed.
+    ledgerWithoutConsumed : LedgerMapping :=
+      for (acc := ledger) (r in nonEphConsumed)
+        {let
+          kind := anomaKind r;
+          account := Resource.npk r;
+          cm := commitment r;
+        in case Map.lookup kind acc of
+             | nothing := acc
+             | just outer :=
+               case Map.lookup account outer of
+                 | nothing := acc
+                 | just inner :=
+                   Map.insert kind (Map.insert account (Set.delete cm inner) outer) acc};
+    -- Replace the ;Set Commitment; in the mapping with one, where the created resource commitments have been added.
+    ledgerWithoutConsumedWithCreated : LedgerMapping :=
+      for (acc := ledgerWithoutConsumed) (r in nonEphCreated)
+        {let
+          kind := anomaKind r;
+          account := Resource.npk r;
+          cm := commitment r;
+        in case Map.lookup kind acc of
+             | nothing := acc
+             | just outer :=
+               case Map.lookup account outer of
+                 | nothing := acc
+                 | just inner :=
+                   Map.insert kind (Map.insert account (Set.insert cm inner) outer) acc};
+  in for (outerAcc := []) (outerKey, outerVal in Map.toList ledgerWithoutConsumedWithCreated)
+       {for (innerAcc := []) (innerKey, innerVal in Map.toList outerVal)
+         {outerAcc
+           ++ [ KeyValue.assign@{
+                key :=
+                  KeyValue.mkKey
+                    (map
+                      natToString
+                      [MyAnoma.Kind.unKind outerKey; PublicKey.unPublicKey innerKey]);
+                value := innerVal
+              }
+              ]}};

--- a/Token/Projection/Balance.juvix
+++ b/Token/Projection/Balance.juvix
@@ -4,15 +4,15 @@ import Stdlib.Prelude open;
 import Data.Set as Set open using {Set};
 import Anoma open;
 
+import Token.Indexing open;
+
 --- Returns the total quantity of all resources  ;Kind; by looking up
 --- a ;Set; of ;Commitment;s associated with an account's ;PublicKey;
 --- from the key-value storage.
 --- This assume that the set is is up-to-date an no ;Commitment;s of
 --- consumed ;Resource;s are present.
 balance (kind : Kind) (account : PublicKey) : Nat :=
-  let
-    ownedResources : Set Commitment := anomaGet (kind, account);
-  in for (sum := 0) (cm in Set.toList ownedResources)
-       {let
-         q := Resource.quantity (commitmentResource cm);
-       in q + sum};
+  for (sum := 0) (cm in Set.toList (anomaGet (ownedCommitmentsKey kind account)))
+    {let
+      q := Resource.quantity (commitmentResource cm);
+    in q + sum};

--- a/Token/Projection/Balance.juvix
+++ b/Token/Projection/Balance.juvix
@@ -12,7 +12,7 @@ import Token.Indexing open;
 --- This assume that the set is is up-to-date an no ;Commitment;s of
 --- consumed ;Resource;s are present.
 balance (kind : Kind) (account : PublicKey) : Nat :=
-  for (sum := 0) (cm in Set.toList (anomaGet (ownedCommitmentsKey kind account)))
+  for (sum := 0) (cm in Set.toList (anomaGet (ledgerKey kind account)))
     {let
       q := Resource.quantity (commitmentResource cm);
     in q + sum};

--- a/Token/Transaction/Finalize.juvix
+++ b/Token/Transaction/Finalize.juvix
@@ -27,14 +27,7 @@ finalize (self : KeyPair) (token : Resource)
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
     | else :=
         case getSupply token of
-          | Unbound := ok (
-              mkTxWithExtraData@{nk; consumed := [token]; created := [ephToken]}, 
-              [removeFromLedger@{
-                kind := anomaKind token;
-                account := myself; 
-                cms := map commitment [token]
-              }]
-            )
+          | Unbound := ok mkTxWithExtraData@{nk; consumed := [token]; created := [ephToken]}
           | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
           | (Fixed _) := throw mkError@{msg := "Tokens with fixed supply cannot be burned."};
 

--- a/Token/Transaction/Finalize.juvix
+++ b/Token/Transaction/Finalize.juvix
@@ -17,18 +17,35 @@ import Token.Indexing open;
 --- Finalizes a token ;Resource;, if the calling ;KeyPair; is the owner.
 --- This requires an ephemeral resource to be created.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
-finalize (self : KeyPair) (token : Resource)
-: Result TokenError (TxData (Set Commitment)) :=
+finalize (self : KeyPair) (token : Resource) : Result TokenError Transaction :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
-    ephToken := token@Resource{eph := true; npk := Zero.pubKey};
+    ephToken := token@Resource{   eph := true; npk := Zero.pubKey };
   in if
-    | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
+    | owner /= myself :=
+      throw
+        mkUnauthorizedError@{
+          expected := myself;
+          actual := owner
+        }
     | else :=
-        case getSupply token of
-          | Unbound := ok mkTxWithExtraData@{nk; consumed := [token]; created := [ephToken]}
-          | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
-          | (Fixed _) := throw mkError@{msg := "Tokens with fixed supply cannot be burned."};
-
+      case getSupply token of
+        | Unbound :=
+          ok
+            mkTxWithExtraData@{
+              nk;
+              consumed := [token];
+              created := [ephToken]
+            }
+        | Capped :=
+          throw
+            mkError@{
+              msg := "Tokens with capped supply are not supported yet."
+            }
+        | Fixed _ :=
+          throw
+            mkError@{
+              msg := "Tokens with fixed supply cannot be burned."
+            };

--- a/Token/Transaction/Finalize.juvix
+++ b/Token/Transaction/Finalize.juvix
@@ -1,6 +1,7 @@
 module Token.Transaction.Finalize;
 
 import Stdlib.Prelude open;
+import Data.Set as Set open using {Set};
 import Anoma open;
 import AnomaHelpers open;
 
@@ -17,7 +18,7 @@ import Token.Indexing open;
 --- This requires an ephemeral resource to be created.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
 finalize (self : KeyPair) (token : Resource)
-: Result TokenError (Pair Transaction (List TokenAssignment)) :=
+: Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Finalize.juvix
+++ b/Token/Transaction/Finalize.juvix
@@ -17,7 +17,7 @@ import Token.Indexing open;
 --- This requires an ephemeral resource to be created.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
 finalize (self : KeyPair) (token : Resource)
-: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+: Result TokenError (Pair Transaction (List TokenAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Finalize.juvix
+++ b/Token/Transaction/Finalize.juvix
@@ -11,6 +11,7 @@ import Token.Resource open;
 import Token.Label open;
 import Token.Supply open;
 import Token.Error open;
+import Token.Indexing open;
 
 --- Finalizes a token ;Resource;, if the calling ;KeyPair; is the owner.
 --- This requires an ephemeral resource to be created.
@@ -22,6 +23,11 @@ finalize (self : KeyPair) (token : Resource)
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
     ephToken := token@Resource{eph := true; npk := Zero.pubKey};
+    assignment : LedgerAssignment := ledgerAssign@{
+      account := myself; 
+      resource := token;
+      operation := Remove
+    };
   in if
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
     | else :=

--- a/Token/Transaction/Finalize.juvix
+++ b/Token/Transaction/Finalize.juvix
@@ -17,22 +17,24 @@ import Token.Indexing open;
 --- This requires an ephemeral resource to be created.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
 finalize (self : KeyPair) (token : Resource)
-: Result TokenError Transaction :=
+: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
     ephToken := token@Resource{eph := true; npk := Zero.pubKey};
-    assignment : LedgerAssignment := ledgerAssign@{
-      account := myself; 
-      resource := token;
-      operation := Remove
-    };
   in if
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
     | else :=
         case getSupply token of
-          | Unbound := ok mkTxWithExtraData@{nk; consumed := [token]; created := [ephToken]}
+          | Unbound := ok (
+              mkTxWithExtraData@{nk; consumed := [token]; created := [ephToken]}, 
+              [removeFromLedger@{
+                kind := anomaKind token;
+                account := myself; 
+                cms := map commitment [token]
+              }]
+            )
           | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
           | (Fixed _) := throw mkError@{msg := "Tokens with fixed supply cannot be burned."};
 

--- a/Token/Transaction/Initialize.juvix
+++ b/Token/Transaction/Initialize.juvix
@@ -11,33 +11,31 @@ import Token.Resource open;
 import Token.Label open;
 import Token.Supply open;
 import Token.Error open;
-
-import Anoma open;
 import Token.Indexing open;
 
 --- Initializes a token ;Resource; owned by an receiver ;PublicKey;.
 --- This requires an ephemeral resource to be consumed.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
 initialize (self : KeyPair) (label : Label) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List (KeyValue.Assignment (Set Commitment)))) :=
+: Result TokenError (Pair Transaction (KeyValue.Assignment (Set Commitment))) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     newToken : Resource := mkToken@{quantity; tokenLabel := label; npk := receiver};
     ephToken := newToken@Resource{npk := myself; eph := true};
     tx : Transaction := mkTxWithExtraData@{nk; consumed := [ephToken]; created := [newToken]};
-    key : KeyValue.Key := ownedCommitmentsKey@{kind := anomaKind newToken; account := myself};
-    -- TODO first grab the current key-value store and update it
-    value : Set Commitment := addOwnedCommitment@{kind := anomaKind newToken; account := myself; cm := commitment newToken };
-    assgnmnt := KeyValue.assign@{key; value};
-    -- TODO how to compose two assignments
+    assignment : LedgerAssignment := ledgerAssign@{
+      account := myself; 
+      resource := newToken;
+      operation := Add
+    };
    in
      case Label.supply label of
-       | Unbound := ok (tx, [assgnmnt])
+       | Unbound := ok (tx, assignment)
        | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
        | (Fixed f) := ok
           (compose@{
             tx1 := tx;
             tx2 := Dummy.finalize@{self; dummy := anomaGet(FixingNullifier.nf f)}
-          }, [assgnmnt] );
+          }, assignment );
 

--- a/Token/Transaction/Initialize.juvix
+++ b/Token/Transaction/Initialize.juvix
@@ -17,25 +17,25 @@ import Token.Indexing open;
 --- This requires an ephemeral resource to be consumed.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
 initialize (self : KeyPair) (label : Label) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (KeyValue.Assignment (Set Commitment))) :=
+: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     newToken : Resource := mkToken@{quantity; tokenLabel := label; npk := receiver};
     ephToken := newToken@Resource{npk := myself; eph := true};
     tx : Transaction := mkTxWithExtraData@{nk; consumed := [ephToken]; created := [newToken]};
-    assignment : LedgerAssignment := ledgerAssign@{
-      account := myself; 
-      resource := newToken;
-      operation := Add
-    };
+    assignments : List LedgerAssignment := [addToLedger@{
+      kind := anomaKind newToken;
+      account := receiver; 
+      cms := map commitment [newToken];
+    }];
    in
      case Label.supply label of
-       | Unbound := ok (tx, assignment)
+       | Unbound := ok (tx, assignments)
        | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
        | (Fixed f) := ok
           (compose@{
             tx1 := tx;
             tx2 := Dummy.finalize@{self; dummy := anomaGet(FixingNullifier.nf f)}
-          }, assignment );
+          }, assignments);
 

--- a/Token/Transaction/Initialize.juvix
+++ b/Token/Transaction/Initialize.juvix
@@ -17,7 +17,7 @@ import Token.Indexing open;
 --- This requires an ephemeral resource to be consumed.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
 initialize (self : KeyPair) (label : Label) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+: Result TokenError (Pair Transaction (List TokenAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Initialize.juvix
+++ b/Token/Transaction/Initialize.juvix
@@ -16,24 +16,46 @@ import Token.Indexing open;
 --- Initializes a token ;Resource; owned by an receiver ;PublicKey;.
 --- This requires an ephemeral resource to be consumed.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
-initialize (self : KeyPair) (label : Label) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError (TxData (Set Commitment)) :=
+initialize
+  (self : KeyPair)
+  (label : Label)
+  (quantity : Nat)
+  (receiver : PublicKey)
+  : Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
-    newToken : Resource := mkToken@{quantity; tokenLabel := label; npk := receiver};
-    ephToken := newToken@Resource{npk := myself; eph := true};
-    returnVal := mkTxWithExtraData@{nk; consumed := [ephToken]; created := [newToken]};
-  in
-    case Label.supply label of
-      | Unbound := ok returnVal
-      | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
-      | (Fixed f) := ok
-        mkTxData@{
-          tx := compose@{
-            tx1 := TxData.tx returnVal;
-            tx2 := Dummy.finalize@{self; dummy := anomaGet(FixingNullifier.nf f)}
-          }; 
-          assignment := TxData.assignment returnVal
-        };
-
+    newToken : Resource :=
+      mkToken@{
+        quantity;
+        tokenLabel := label;
+        npk := receiver
+      };
+    ephToken := newToken@Resource{   npk := myself; eph := true };
+    returnVal :=
+      mkTxWithExtraData@{
+        nk;
+        consumed := [ephToken];
+        created := [newToken]
+      };
+  in case Label.supply label of
+       | Unbound := ok returnVal
+       | Capped :=
+         throw
+           mkError@{
+             msg := "Tokens with capped supply are not supported yet."
+           }
+       | Fixed f :=
+         ok
+           mkTxData@{
+             tx :=
+               compose@{
+                 tx1 := TxData.tx returnVal;
+                 tx2 :=
+                   Dummy.finalize@{
+                     self;
+                     dummy := anomaGet (FixingNullifier.nf f)
+                   }
+               };
+             assignment := TxData.assignment returnVal
+           };

--- a/Token/Transaction/Initialize.juvix
+++ b/Token/Transaction/Initialize.juvix
@@ -21,7 +21,7 @@ initialize
   (label : Label)
   (quantity : Nat)
   (receiver : PublicKey)
-  : Result TokenError (TxData (Set Commitment)) :=
+  : Result TokenError Transaction :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
@@ -47,15 +47,11 @@ initialize
            }
        | Fixed f :=
          ok
-           mkTxData@{
-             tx :=
-               compose@{
-                 tx1 := TxData.tx returnVal;
-                 tx2 :=
-                   Dummy.finalize@{
-                     self;
-                     dummy := anomaGet (FixingNullifier.nf f)
-                   }
-               };
-             assignment := TxData.assignment returnVal
+           compose@{
+             tx1 := returnVal;
+             tx2 :=
+               Dummy.finalize@{
+                 self;
+                 dummy := anomaGet (FixingNullifier.nf f)
+               }
            };

--- a/Token/Transaction/Initialize.juvix
+++ b/Token/Transaction/Initialize.juvix
@@ -17,20 +17,23 @@ import Token.Indexing open;
 --- This requires an ephemeral resource to be consumed.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
 initialize (self : KeyPair) (label : Label) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List TokenAssignment)) :=
+: Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     newToken : Resource := mkToken@{quantity; tokenLabel := label; npk := receiver};
     ephToken := newToken@Resource{npk := myself; eph := true};
     returnVal := mkTxWithExtraData@{nk; consumed := [ephToken]; created := [newToken]};
-   in
-     case Label.supply label of
-       | Unbound := ok returnVal
-       | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
-       | (Fixed f) := ok
-          (compose@{
-            tx1 := fst returnVal;
+  in
+    case Label.supply label of
+      | Unbound := ok returnVal
+      | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
+      | (Fixed f) := ok
+        mkTxData@{
+          tx := compose@{
+            tx1 := TxData.tx returnVal;
             tx2 := Dummy.finalize@{self; dummy := anomaGet(FixingNullifier.nf f)}
-          }, snd returnVal);
+          }; 
+          assignment := TxData.assignment returnVal
+        };
 

--- a/Token/Transaction/Initialize.juvix
+++ b/Token/Transaction/Initialize.juvix
@@ -1,7 +1,7 @@
 module Token.Transaction.Initialize;
 
 import Stdlib.Prelude open;
-import Data.Map open;
+import Data.Set as Set open using {Set};
 import Anoma open;
 import AnomaHelpers open;
 
@@ -12,24 +12,32 @@ import Token.Label open;
 import Token.Supply open;
 import Token.Error open;
 
+import Anoma open;
+import Token.Indexing open;
+
 --- Initializes a token ;Resource; owned by an receiver ;PublicKey;.
 --- This requires an ephemeral resource to be consumed.
 --- The function returns a ;TokenError; if the calling ;KeyPair; is not the owner.
 initialize (self : KeyPair) (label : Label) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError Transaction :=
+: Result TokenError (Pair Transaction (List (KeyValue.Assignment (Set Commitment)))) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     newToken : Resource := mkToken@{quantity; tokenLabel := label; npk := receiver};
     ephToken := newToken@Resource{npk := myself; eph := true};
     tx : Transaction := mkTxWithExtraData@{nk; consumed := [ephToken]; created := [newToken]};
+    key : KeyValue.Key := ownedCommitmentsKey@{kind := anomaKind newToken; account := myself};
+    -- TODO first grab the current key-value store and update it
+    value : Set Commitment := addOwnedCommitment@{kind := anomaKind newToken; account := myself; cm := commitment newToken };
+    assgnmnt := KeyValue.assign@{key; value};
+    -- TODO how to compose two assignments
    in
      case Label.supply label of
-       | Unbound := ok tx
+       | Unbound := ok (tx, [assgnmnt])
        | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
        | (Fixed f) := ok
-          compose@{
+          (compose@{
             tx1 := tx;
             tx2 := Dummy.finalize@{self; dummy := anomaGet(FixingNullifier.nf f)}
-          };
+          }, [assgnmnt] );
 

--- a/Token/Transaction/Initialize.juvix
+++ b/Token/Transaction/Initialize.juvix
@@ -23,19 +23,14 @@ initialize (self : KeyPair) (label : Label) (quantity : Nat) (receiver : PublicK
     nk : PrivateKey := KeyPair.privKey self;
     newToken : Resource := mkToken@{quantity; tokenLabel := label; npk := receiver};
     ephToken := newToken@Resource{npk := myself; eph := true};
-    tx : Transaction := mkTxWithExtraData@{nk; consumed := [ephToken]; created := [newToken]};
-    assignments : List LedgerAssignment := [addToLedger@{
-      kind := anomaKind newToken;
-      account := receiver; 
-      cms := map commitment [newToken];
-    }];
+    returnVal := mkTxWithExtraData@{nk; consumed := [ephToken]; created := [newToken]};
    in
      case Label.supply label of
-       | Unbound := ok (tx, assignments)
+       | Unbound := ok returnVal
        | Capped := throw mkError@{msg := "Tokens with capped supply are not supported yet."}
        | (Fixed f) := ok
           (compose@{
-            tx1 := tx;
+            tx1 := fst returnVal;
             tx2 := Dummy.finalize@{self; dummy := anomaGet(FixingNullifier.nf f)}
-          }, assignments);
+          }, snd returnVal);
 

--- a/Token/Transaction/Merge.juvix
+++ b/Token/Transaction/Merge.juvix
@@ -21,7 +21,7 @@ merge
   (self : KeyPair)
   (tokens : List Resource)
   (receiver : PublicKey)
-  : Result TokenError (TxData (Set Commitment)) :=
+  : Result TokenError Transaction :=
   case tokens of
     | nil :=
       throw

--- a/Token/Transaction/Merge.juvix
+++ b/Token/Transaction/Merge.juvix
@@ -36,10 +36,4 @@ merge (self : KeyPair) (tokens : List Resource) (receiver : PublicKey)
               case find ((/=) kind) (map anomaKind tokens) of
                 | just otherKind := throw mkInvalidKindError@{expected := kind; actual := otherKind}
                 | nothing := 
-                  ok (
-                    mkTxWithExtraData@{nk; consumed := tokens; created := [merged]},
-                    [
-                      removeFromLedger kind myself (map commitment tokens);
-                      addToLedger kind receiver [commitment merged]
-                    ]
-                  );
+                  ok mkTxWithExtraData@{nk; consumed := tokens; created := [merged]};

--- a/Token/Transaction/Merge.juvix
+++ b/Token/Transaction/Merge.juvix
@@ -1,4 +1,4 @@
-module Token.Transaction.Merg;
+module Token.Transaction.Merge;
 
 import Stdlib.Prelude open;
 import Data.Set as Set open using {Set};
@@ -17,24 +17,47 @@ import Token.Indexing open;
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner of the tokens or
 --- - one of the token ;Kind;s differ
-merge (self : KeyPair) (tokens : List Resource) (receiver : PublicKey)
-: Result TokenError (TxData (Set Commitment)) :=
+merge
+  (self : KeyPair)
+  (tokens : List Resource)
+  (receiver : PublicKey)
+  : Result TokenError (TxData (Set Commitment)) :=
   case tokens of
-    | nil := throw mkInsufficientElementsError@{limit := 1; actual := 0}
-    | (t :: _) :=
-    let
-      myself : PublicKey := KeyPair.pubKey self;
-      nk : PrivateKey := KeyPair.privKey self;
-      kind : Kind := anomaKind t;
-      totalQuantity : Nat := for (acc := 0) (t in tokens) {Resource.quantity t + acc};
-      merged := t@Resource{quantity := totalQuantity; npk := receiver};
-    in if 
+    | nil :=
+      throw
+        mkInsufficientElementsError@{
+          limit := 1;
+          actual := 0
+        }
+    | t :: _ :=
+      let
+        myself : PublicKey := KeyPair.pubKey self;
+        nk : PrivateKey := KeyPair.privKey self;
+        kind : Kind := anomaKind t;
+        totalQuantity : Nat := for (acc := 0) (t in tokens) {Resource.quantity t + acc};
+        merged := t@Resource{   quantity := totalQuantity; npk := receiver };
+      in if
         | not (isTransferable t) := throw mkNonTransferableError
         | else :=
           case find ((/=) myself) (map Resource.npk tokens) of
-            | just notMyself := throw mkUnauthorizedError@{expected := myself; actual := notMyself}
+            | just notMyself :=
+              throw
+                mkUnauthorizedError@{
+                  expected := myself;
+                  actual := notMyself
+                }
             | nothing :=
               case find ((/=) kind) (map anomaKind tokens) of
-                | just otherKind := throw mkInvalidKindError@{expected := kind; actual := otherKind}
-                | nothing := 
-                  ok mkTxWithExtraData@{nk; consumed := tokens; created := [merged]};
+                | just otherKind :=
+                  throw
+                    mkInvalidKindError@{
+                      expected := kind;
+                      actual := otherKind
+                    }
+                | nothing :=
+                  ok
+                    mkTxWithExtraData@{
+                      nk;
+                      consumed := tokens;
+                      created := [merged]
+                    };

--- a/Token/Transaction/Merge.juvix
+++ b/Token/Transaction/Merge.juvix
@@ -17,7 +17,7 @@ import Token.Indexing open;
 --- - the calling ;KeyPair; is not the owner of the tokens or
 --- - one of the token ;Kind;s differ
 merge (self : KeyPair) (tokens : List Resource) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+: Result TokenError (Pair Transaction (List TokenAssignment)) :=
   case tokens of
     | nil := throw mkInsufficientElementsError@{limit := 1; actual := 0}
     | (t :: _) :=

--- a/Token/Transaction/Merge.juvix
+++ b/Token/Transaction/Merge.juvix
@@ -8,6 +8,7 @@ import Authorization.Check open;
 import Authorization.Message open;
 import Token.Label open;
 import Token.Error open;
+import Token.Indexing open;
 
 --- Merges token ;Resource;s, if the calling ;KeyPair; is the owner of all
 --- of them and the ;Kind;s match.
@@ -16,7 +17,7 @@ import Token.Error open;
 --- - the calling ;KeyPair; is not the owner of the tokens or
 --- - one of the token ;Kind;s differ
 merge (self : KeyPair) (tokens : List Resource) (receiver : PublicKey)
-: Result TokenError Transaction :=
+: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   case tokens of
     | nil := throw mkInsufficientElementsError@{limit := 1; actual := 0}
     | (t :: _) :=
@@ -34,4 +35,11 @@ merge (self : KeyPair) (tokens : List Resource) (receiver : PublicKey)
             | nothing :=
               case find ((/=) kind) (map anomaKind tokens) of
                 | just otherKind := throw mkInvalidKindError@{expected := kind; actual := otherKind}
-                | nothing := ok mkTxWithExtraData@{nk; consumed := tokens; created := [merged]};
+                | nothing := 
+                  ok (
+                    mkTxWithExtraData@{nk; consumed := tokens; created := [merged]},
+                    [
+                      removeFromLedger kind myself (map commitment tokens);
+                      addToLedger kind receiver [commitment merged]
+                    ]
+                  );

--- a/Token/Transaction/Merge.juvix
+++ b/Token/Transaction/Merge.juvix
@@ -1,6 +1,7 @@
-module Token.Transaction.Merge;
+module Token.Transaction.Merg;
 
 import Stdlib.Prelude open;
+import Data.Set as Set open using {Set};
 import Anoma open;
 import AnomaHelpers open;
 
@@ -17,7 +18,7 @@ import Token.Indexing open;
 --- - the calling ;KeyPair; is not the owner of the tokens or
 --- - one of the token ;Kind;s differ
 merge (self : KeyPair) (tokens : List Resource) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List TokenAssignment)) :=
+: Result TokenError (TxData (Set Commitment)) :=
   case tokens of
     | nil := throw mkInsufficientElementsError@{limit := 1; actual := 0}
     | (t :: _) :=

--- a/Token/Transaction/Send.juvix
+++ b/Token/Transaction/Send.juvix
@@ -4,7 +4,7 @@ import Stdlib.Prelude open;
 import Stdlib.Data.Nat.Ord open using {compare};
 import Data.Set as Set open using {Set};
 import Anoma open;
-import AnomaHelpers open using {mkInsufficientQuantityError; TxData};
+import AnomaHelpers open using {mkInsufficientQuantityError};
 
 import Token.Error open;
 import Token.Indexing open;
@@ -22,7 +22,7 @@ send
   (token : Resource)
   (quantity : Nat)
   (receiver : PublicKey)
-  : Result TokenError (TxData (Set Commitment)) :=
+  : Result TokenError Transaction :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     balance : Nat := Resource.quantity token;

--- a/Token/Transaction/Send.juvix
+++ b/Token/Transaction/Send.juvix
@@ -3,7 +3,7 @@ module Token.Transaction.Send;
 import Stdlib.Prelude open;
 import Stdlib.Data.Nat.Ord open using {compare};
 import Anoma open;
-import AnomaHelpers open;
+import AnomaHelpers open using {mkInsufficientQuantityError};
 
 import Token.Error open;
 import Token.Indexing open;

--- a/Token/Transaction/Send.juvix
+++ b/Token/Transaction/Send.juvix
@@ -16,16 +16,24 @@ import Token.Transaction.Split open;
 --- The function returns a ;TokenError; if
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantity exceeds the quantity of the resource.
-send (self : KeyPair) (token : Resource) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+send
+  (self : KeyPair)
+  (token : Resource)
+  (quantity : Nat)
+  (receiver : PublicKey)
+  : Result TokenError (Pair Transaction (List TokenAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     balance : Nat := Resource.quantity token;
-  in case (compare balance quantity) of
-      | LT := throw mkInsufficientQuantityError@{limit := balance; actual := quantity}
-      | EQ := transfer self token receiver
-      | GT :=
-        let
-          difference : Nat := toNat (intSubNat balance quantity);
-        in
-          split self token [(quantity, receiver); (difference, myself)];
+  in case compare balance quantity of
+       | LT :=
+         throw
+           mkInsufficientQuantityError@{
+             limit := balance;
+             actual := quantity
+           }
+       | EQ := transfer self token receiver
+       | GT :=
+         let
+           difference : Nat := toNat (intSubNat balance quantity);
+         in split self token [quantity, receiver; difference, myself];

--- a/Token/Transaction/Send.juvix
+++ b/Token/Transaction/Send.juvix
@@ -6,6 +6,7 @@ import Anoma open;
 import AnomaHelpers open;
 
 import Token.Error open;
+import Token.Indexing open;
 import Token.Transaction.Transfer open;
 import Token.Transaction.Split open;
 
@@ -16,7 +17,7 @@ import Token.Transaction.Split open;
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantity exceeds the quantity of the resource.
 send (self : KeyPair) (token : Resource) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError Transaction  :=
+: Result TokenError (Pair Transaction (List LedgerAssignment))  :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     balance : Nat := Resource.quantity token;

--- a/Token/Transaction/Send.juvix
+++ b/Token/Transaction/Send.juvix
@@ -21,7 +21,7 @@ send
   (token : Resource)
   (quantity : Nat)
   (receiver : PublicKey)
-  : Result TokenError (Pair Transaction (List TokenAssignment)) :=
+  : Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     balance : Nat := Resource.quantity token;

--- a/Token/Transaction/Send.juvix
+++ b/Token/Transaction/Send.juvix
@@ -2,8 +2,9 @@ module Token.Transaction.Send;
 
 import Stdlib.Prelude open;
 import Stdlib.Data.Nat.Ord open using {compare};
+import Data.Set as Set open using {Set};
 import Anoma open;
-import AnomaHelpers open using {mkInsufficientQuantityError};
+import AnomaHelpers open using {mkInsufficientQuantityError; TxData};
 
 import Token.Error open;
 import Token.Indexing open;

--- a/Token/Transaction/Send.juvix
+++ b/Token/Transaction/Send.juvix
@@ -17,7 +17,7 @@ import Token.Transaction.Split open;
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantity exceeds the quantity of the resource.
 send (self : KeyPair) (token : Resource) (quantity : Nat) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List LedgerAssignment))  :=
+: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     balance : Nat := Resource.quantity token;

--- a/Token/Transaction/Split.juvix
+++ b/Token/Transaction/Split.juvix
@@ -9,6 +9,7 @@ import Authorization.Message open;
 import Token.Label open;
 import Token.Resource open;
 import Token.Error open;
+import Token.Indexing open;
 
 
 --- Splits a token ;Resource;, if the calling ;KeyPair; is the owner.
@@ -17,20 +18,27 @@ import Token.Error open;
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantities do not balance,
 split (self : KeyPair) (token : Resource) (quantitiesAndReceivers : List (Pair Nat PublicKey))
-: Result TokenError Transaction :=
+: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
     label : Label := anomaDecode (Resource.label token);
+    kind : Kind := anomaKind token;
     sum : Nat := for (acc := 0) ((quantity, _) in quantitiesAndReceivers) {quantity + acc};
     balance := Resource.quantity token;
     created : List Resource := map ((quantity, receiver) in quantitiesAndReceivers) {
         mkToken@{quantity; tokenLabel := label; npk := receiver}
       };
+    assignments : List LedgerAssignment := 
+      [removeFromLedger@{kind; account := myself; cms := [commitment token]}] 
+      ++ 
+      map (r in created) {
+        addToLedger@{kind; account := Resource.npk r; cms := [commitment r]}
+      }
   in if
     | not (isTransferable token) := throw mkNonTransferableError
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
     | balance /= sum := throw mkInsufficientQuantityError@{limit := balance; actual := sum}
-    | else := ok mkTxWithExtraData@{nk; consumed := [token]; created};
+    | else := ok (mkTxWithExtraData@{nk; consumed := [token]; created}, assignments);
 

--- a/Token/Transaction/Split.juvix
+++ b/Token/Transaction/Split.juvix
@@ -11,65 +11,36 @@ import Token.Resource open;
 import Token.Error open;
 import Token.Indexing open;
 
+
 --- Splits a token ;Resource;, if the calling ;KeyPair; is the owner.
 --- The function returns a ;TokenError; if
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantities do not balance,
-split
-  (self : KeyPair)
-  (token : Resource)
-  (quantitiesAndReceivers : List (Pair Nat PublicKey))
-  : Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+split (self : KeyPair) (token : Resource) (quantitiesAndReceivers : List (Pair Nat PublicKey))
+: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
     label : Label := anomaDecode (Resource.label token);
     kind : Kind := anomaKind token;
-    sum : Nat := for (acc := 0) (quantity, _ in quantitiesAndReceivers) {quantity + acc};
+    sum : Nat := for (acc := 0) ((quantity, _) in quantitiesAndReceivers) {quantity + acc};
     balance := Resource.quantity token;
-    created : List Resource :=
-      map (quantity, receiver in quantitiesAndReceivers)
-        {mkToken@{
-          quantity;
-          tokenLabel := label;
-          npk := receiver
-        }};
+    created : List Resource := map ((quantity, receiver) in quantitiesAndReceivers) {
+        mkToken@{quantity; tokenLabel := label; npk := receiver}
+      };
     -- TODO handle the special case where `self` is also a `receiver`.
     -- Here we must make sure, that there is only one assignment returned.
-    assignments : List LedgerAssignment :=
-      [ removeFromLedger@{
-        kind;
-        account := myself;
-        cms := [commitment token]
+    assignments : List LedgerAssignment := 
+      [removeFromLedger@{kind; account := myself; cms := [commitment token]}] 
+      ++ 
+      map (r in created) {
+        addToLedger@{kind; account := Resource.npk r; cms := [commitment r]}
       }
-      ]
-        ++ map (r in created)
-             {addToLedger@{
-               kind;
-               account := Resource.npk r;
-               cms := [commitment r]
-             }};
   in if
     | not (isTransferable token) := throw mkNonTransferableError
-    | owner /= myself :=
-      throw
-        mkUnauthorizedError@{
-          expected := myself;
-          actual := owner
-        }
-    | balance /= sum :=
-      throw
-        mkInsufficientQuantityError@{
-          limit := balance;
-          actual := sum
-        }
-    | else :=
-      ok
-        (mkTxWithExtraData@{
-            nk;
-            consumed := [token];
-            created
-          }
-          , assignments);
+    | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
+    | balance /= sum := throw mkInsufficientQuantityError@{limit := balance; actual := sum}
+    | else := ok mkTxWithExtraData@{nk; consumed := [token]; created};
+

--- a/Token/Transaction/Split.juvix
+++ b/Token/Transaction/Split.juvix
@@ -17,22 +17,44 @@ import Token.Indexing open;
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantities do not balance,
-split (self : KeyPair) (token : Resource) (quantitiesAndReceivers : List (Pair Nat PublicKey))
-: Result TokenError (TxData (Set Commitment)) :=
+split
+  (self : KeyPair)
+  (token : Resource)
+  (quantitiesAndReceivers : List (Pair Nat PublicKey))
+  : Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
     label : Label := anomaDecode (Resource.label token);
     kind : Kind := anomaKind token;
-    sum : Nat := for (acc := 0) ((quantity, _) in quantitiesAndReceivers) {quantity + acc};
+    sum : Nat := for (acc := 0) (quantity, _ in quantitiesAndReceivers) {quantity + acc};
     balance := Resource.quantity token;
-    created : List Resource := map ((quantity, receiver) in quantitiesAndReceivers) {
-        mkToken@{quantity; tokenLabel := label; npk := receiver}
-      };
+    created : List Resource :=
+      map (quantity, receiver in quantitiesAndReceivers)
+        {mkToken@{
+          quantity;
+          tokenLabel := label;
+          npk := receiver
+        }};
   in if
     | not (isTransferable token) := throw mkNonTransferableError
-    | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
-    | balance /= sum := throw mkInsufficientQuantityError@{limit := balance; actual := sum}
-    | else := ok mkTxWithExtraData@{nk; consumed := [token]; created};
-
+    | owner /= myself :=
+      throw
+        mkUnauthorizedError@{
+          expected := myself;
+          actual := owner
+        }
+    | balance /= sum :=
+      throw
+        mkInsufficientQuantityError@{
+          limit := balance;
+          actual := sum
+        }
+    | else :=
+      ok
+        mkTxWithExtraData@{
+          nk;
+          consumed := [token];
+          created
+        };

--- a/Token/Transaction/Split.juvix
+++ b/Token/Transaction/Split.juvix
@@ -18,7 +18,7 @@ import Token.Indexing open;
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantities do not balance,
 split (self : KeyPair) (token : Resource) (quantitiesAndReceivers : List (Pair Nat PublicKey))
-: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+: Result TokenError (Pair Transaction (List TokenAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Split.juvix
+++ b/Token/Transaction/Split.juvix
@@ -11,34 +11,65 @@ import Token.Resource open;
 import Token.Error open;
 import Token.Indexing open;
 
-
 --- Splits a token ;Resource;, if the calling ;KeyPair; is the owner.
 --- The function returns a ;TokenError; if
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantities do not balance,
-split (self : KeyPair) (token : Resource) (quantitiesAndReceivers : List (Pair Nat PublicKey))
-: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+split
+  (self : KeyPair)
+  (token : Resource)
+  (quantitiesAndReceivers : List (Pair Nat PublicKey))
+  : Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
     label : Label := anomaDecode (Resource.label token);
     kind : Kind := anomaKind token;
-    sum : Nat := for (acc := 0) ((quantity, _) in quantitiesAndReceivers) {quantity + acc};
+    sum : Nat := for (acc := 0) (quantity, _ in quantitiesAndReceivers) {quantity + acc};
     balance := Resource.quantity token;
-    created : List Resource := map ((quantity, receiver) in quantitiesAndReceivers) {
-        mkToken@{quantity; tokenLabel := label; npk := receiver}
-      };
-    assignments : List LedgerAssignment := 
-      [removeFromLedger@{kind; account := myself; cms := [commitment token]}] 
-      ++ 
-      map (r in created) {
-        addToLedger@{kind; account := Resource.npk r; cms := [commitment r]}
+    created : List Resource :=
+      map (quantity, receiver in quantitiesAndReceivers)
+        {mkToken@{
+          quantity;
+          tokenLabel := label;
+          npk := receiver
+        }};
+    -- TODO handle the special case where `self` is also a `receiver`.
+    -- Here we must make sure, that there is only one assignment returned.
+    assignments : List LedgerAssignment :=
+      [ removeFromLedger@{
+        kind;
+        account := myself;
+        cms := [commitment token]
       }
+      ]
+        ++ map (r in created)
+             {addToLedger@{
+               kind;
+               account := Resource.npk r;
+               cms := [commitment r]
+             }};
   in if
     | not (isTransferable token) := throw mkNonTransferableError
-    | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
-    | balance /= sum := throw mkInsufficientQuantityError@{limit := balance; actual := sum}
-    | else := ok (mkTxWithExtraData@{nk; consumed := [token]; created}, assignments);
-
+    | owner /= myself :=
+      throw
+        mkUnauthorizedError@{
+          expected := myself;
+          actual := owner
+        }
+    | balance /= sum :=
+      throw
+        mkInsufficientQuantityError@{
+          limit := balance;
+          actual := sum
+        }
+    | else :=
+      ok
+        (mkTxWithExtraData@{
+            nk;
+            consumed := [token];
+            created
+          }
+          , assignments);

--- a/Token/Transaction/Split.juvix
+++ b/Token/Transaction/Split.juvix
@@ -30,14 +30,6 @@ split (self : KeyPair) (token : Resource) (quantitiesAndReceivers : List (Pair N
     created : List Resource := map ((quantity, receiver) in quantitiesAndReceivers) {
         mkToken@{quantity; tokenLabel := label; npk := receiver}
       };
-    -- TODO handle the special case where `self` is also a `receiver`.
-    -- Here we must make sure, that there is only one assignment returned.
-    assignments : List LedgerAssignment := 
-      [removeFromLedger@{kind; account := myself; cms := [commitment token]}] 
-      ++ 
-      map (r in created) {
-        addToLedger@{kind; account := Resource.npk r; cms := [commitment r]}
-      }
   in if
     | not (isTransferable token) := throw mkNonTransferableError
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}

--- a/Token/Transaction/Split.juvix
+++ b/Token/Transaction/Split.juvix
@@ -21,7 +21,7 @@ split
   (self : KeyPair)
   (token : Resource)
   (quantitiesAndReceivers : List (Pair Nat PublicKey))
-  : Result TokenError (TxData (Set Commitment)) :=
+  : Result TokenError Transaction :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Split.juvix
+++ b/Token/Transaction/Split.juvix
@@ -1,6 +1,7 @@
 module Token.Transaction.Split;
 
 import Stdlib.Prelude open;
+import Data.Set as Set open using {Set};
 import Anoma open;
 import AnomaHelpers open;
 
@@ -11,14 +12,13 @@ import Token.Resource open;
 import Token.Error open;
 import Token.Indexing open;
 
-
 --- Splits a token ;Resource;, if the calling ;KeyPair; is the owner.
 --- The function returns a ;TokenError; if
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner or
 --- - the quantities do not balance,
 split (self : KeyPair) (token : Resource) (quantitiesAndReceivers : List (Pair Nat PublicKey))
-: Result TokenError (Pair Transaction (List TokenAssignment)) :=
+: Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Swap.juvix
+++ b/Token/Transaction/Swap.juvix
@@ -25,11 +25,9 @@ swap (self : KeyPair) (token : Resource) (want : QuantifiedAssets) (solver : Pub
   in if
     | not (isTransferable token) := throw mkNonTransferableError
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
-    | else := ok (
+    | else := ok 
         mkTxWithExtraData@{
           nk;
           consumed := [token];
           created := [mkSwapIntent@{want; receiver := myself; solver}]
-        },
-        [removeFromLedger@{kind := anomaKind token; account := myself; cms := [commitment token]}]
-      );
+        };

--- a/Token/Transaction/Swap.juvix
+++ b/Token/Transaction/Swap.juvix
@@ -15,59 +15,72 @@ import Token.Indexing open;
 import Token.Transaction.Swap.Resource open;
 import Token.Transaction.Swap.Solution open;
 
---- Swaps a token ;Resource; for a list of ;QuantifiedAssets;.
+--- Swaps a token ;Resource; ;Set; for a list of ;QuantifiedAssets;.
 --- The function returns a ;TokenError; if
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner of the token.
 swap
   (self : KeyPair)
-  (give : Set Resource)
+  -- TODO use Set
+  (give : List Resource)
   (want : QuantifiedAssets)
   (solver : PublicKey)
   : Result TokenError Transaction :=
-  let
-    giveList := Set.toList give;
-  in case giveList of
-       | nil :=
-         throw
-           mkInsufficientElementsError@{
-             limit := 1;
-             actual := 0
-           }
-       | t :: _ :=
-         let
-           myself : PublicKey := KeyPair.pubKey self;
-           nk : PrivateKey := KeyPair.privKey self;
-           owner : PublicKey := Resource.npk t;
-         in if
-           | not (isTransferable t) := throw mkNonTransferableError
-           | else :=
-             case find ((/=) myself) (map Resource.npk giveList) of
-               | just notMyself :=
-                 throw
-                   mkUnauthorizedError@{
-                     expected := myself;
-                     actual := notMyself
-                   }
-               | nothing :=
-                 ok
-                   mkTxWithExtraData@{
-                     nk;
-                     consumed := giveList;
-                     created :=
-                       [ mkSwapIntent@{
-                         want;
-                         receiver := myself;
-                         solver
-                       }
-                       ]
-                   };
+  case give of
+    | nil :=
+      throw
+        mkInsufficientElementsError@{
+          limit := 1;
+          actual := 0
+        }
+    | t :: _ :=
+      let
+        myself : PublicKey := KeyPair.pubKey self;
+        nk : PrivateKey := KeyPair.privKey self;
+        owner : PublicKey := Resource.npk t;
+      in if
+        | not (isTransferable t) := throw mkNonTransferableError
+        | else :=
+          case find ((/=) myself) (map Resource.npk give) of
+            | just notMyself :=
+              throw
+                mkUnauthorizedError@{
+                  expected := myself;
+                  actual := notMyself
+                }
+            | nothing :=
+              ok
+                mkTxWithExtraData@{
+                  nk;
+                  consumed := give;
+                  created :=
+                    [ mkSwapIntent@{
+                      want;
+                      receiver := myself;
+                      solver
+                    }
+                    ]
+                };
 
+--- Settles a ;Transaction; ;Set; by composing them with
+--- ;Transaction;s obtained from a ;Solution; ;Set;.
+--- The function returns a ;TokenError; if
+--- - the calling ;KeyPair; is not designated intent solver.
 settle
   (self : KeyPair)
-  (solutions : Set Solution)
+  -- TODO use Set
   (txs : List Transaction)
+  -- TODO use Set
+  (solutions : List Solution)
   : Result TokenError Transaction :=
   let
-    solutionTxs : List Transaction := map (Solution.toTransaction self) (Set.toList solutions);
-  in ok (composeAll (txs ++ solutionTxs));
+    myself := KeyPair.pubKey self;
+    solutionTxs := map (Solution.toTransaction self) (solutions);
+  in case find ((/=) myself) (map \ {s := Resource.npk (Solution.intent s)} solutions) of
+       | just notMyself :=
+         throw
+           mkUnauthorizedError@{
+             expected := myself;
+             actual := notMyself
+           }
+       | nothing := ok (composeAll (txs ++ solutionTxs));

--- a/Token/Transaction/Swap.juvix
+++ b/Token/Transaction/Swap.juvix
@@ -62,8 +62,8 @@ swap
                     ]
                 };
 
---- Settles a ;Transaction; ;Set; by composing them with
---- ;Transaction;s obtained from a ;Solution; ;Set;.
+--- Settles a ;Set; of ;Transaction;s by composing them with
+--- ;Transaction;s obtained from a ;Set; of ;Solution;.
 --- The function returns a ;TokenError; if
 --- - the calling ;KeyPair; is not designated intent solver.
 settle

--- a/Token/Transaction/Swap.juvix
+++ b/Token/Transaction/Swap.juvix
@@ -17,7 +17,7 @@ import Token.Indexing open;
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner of the token.
 swap (self : KeyPair) (token : Resource) (want : QuantifiedAssets) (solver : PublicKey)
-: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+: Result TokenError (Pair Transaction (List TokenAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Swap.juvix
+++ b/Token/Transaction/Swap.juvix
@@ -2,6 +2,7 @@ module Token.Transaction.Swap;
 
 import Stdlib.Prelude open;
 import Data.Set as Set open using {Set};
+import Data.Map as Map open using {empty};
 import Anoma open;
 import AnomaHelpers open;
 
@@ -10,25 +11,64 @@ import Authorization.Message open;
 import Intent.Asset open;
 import Token.Error open;
 import Token.Label open;
-import Token.Transaction.Swap.Resource open;
 import Token.Indexing open;
+import Token.Transaction.Swap.Resource open;
+import Token.Transaction.Swap.Solution open;
 
 --- Swaps a token ;Resource; for a list of ;QuantifiedAssets;.
 --- The function returns a ;TokenError; if
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner of the token.
-swap (self : KeyPair) (token : Resource) (want : QuantifiedAssets) (solver : PublicKey)
-: Result TokenError (TxData (Set Commitment)) :=
+swap
+  (self : KeyPair)
+  (give : Set Resource)
+  (want : QuantifiedAssets)
+  (solver : PublicKey)
+  : Result TokenError (TxData (Set Commitment)) :=
   let
-    myself : PublicKey := KeyPair.pubKey self;
-    nk : PrivateKey := KeyPair.privKey self;
-    owner : PublicKey := Resource.npk token;
-  in if
-    | not (isTransferable token) := throw mkNonTransferableError
-    | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
-    | else := ok 
-        mkTxWithExtraData@{
-          nk;
-          consumed := [token];
-          created := [mkSwapIntent@{want; receiver := myself; solver}]
-        };
+    giveList := Set.toList give;
+  in case giveList of
+       | nil :=
+         throw
+           mkInsufficientElementsError@{
+             limit := 1;
+             actual := 0
+           }
+       | t :: _ :=
+         let
+           myself : PublicKey := KeyPair.pubKey self;
+           nk : PrivateKey := KeyPair.privKey self;
+           owner : PublicKey := Resource.npk t;
+         in if
+           | not (isTransferable t) := throw mkNonTransferableError
+           | else :=
+             case find ((/=) myself) (map Resource.npk giveList) of
+               | just notMyself :=
+                 throw
+                   mkUnauthorizedError@{
+                     expected := myself;
+                     actual := notMyself
+                   }
+               | nothing :=
+                 ok
+                   mkTxWithExtraData@{
+                     nk;
+                     consumed := giveList;
+                     created :=
+                       [ mkSwapIntent@{
+                         want;
+                         receiver := myself;
+                         solver
+                       }
+                       ]
+                   };
+
+settle
+  (self : KeyPair)
+  (solutions : Set Solution)
+  (txDatas : List (TxData (Set Commitment)))
+  : Result TokenError (TxData (Set Commitment)) :=
+  let
+    appliedSolutions : List (TxData (Set Commitment)) :=
+      map (Solution.toTxData self) (Set.toList solutions);
+  in ok (composeAllTxData (appliedSolutions ++ txDatas));

--- a/Token/Transaction/Swap.juvix
+++ b/Token/Transaction/Swap.juvix
@@ -24,7 +24,7 @@ swap
   (give : Set Resource)
   (want : QuantifiedAssets)
   (solver : PublicKey)
-  : Result TokenError (TxData (Set Commitment)) :=
+  : Result TokenError Transaction :=
   let
     giveList := Set.toList give;
   in case giveList of
@@ -66,9 +66,8 @@ swap
 settle
   (self : KeyPair)
   (solutions : Set Solution)
-  (txDatas : List (TxData (Set Commitment)))
-  : Result TokenError (TxData (Set Commitment)) :=
+  (txs : List Transaction)
+  : Result TokenError Transaction :=
   let
-    appliedSolutions : List (TxData (Set Commitment)) :=
-      map (Solution.toTxData self) (Set.toList solutions);
-  in ok (composeAllTxData (appliedSolutions ++ txDatas));
+    solutionTxs : List Transaction := map (Solution.toTransaction self) (Set.toList solutions);
+  in ok (composeAll (txs ++ solutionTxs));

--- a/Token/Transaction/Swap.juvix
+++ b/Token/Transaction/Swap.juvix
@@ -10,13 +10,14 @@ import Intent.Asset open;
 import Token.Error open;
 import Token.Label open;
 import Token.Transaction.Swap.Resource open;
+import Token.Indexing open;
 
 --- Swaps a token ;Resource; for a list of ;QuantifiedAssets;.
 --- The function returns a ;TokenError; if
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner of the token.
 swap (self : KeyPair) (token : Resource) (want : QuantifiedAssets) (solver : PublicKey)
-: Result TokenError Transaction :=
+: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
@@ -24,9 +25,11 @@ swap (self : KeyPair) (token : Resource) (want : QuantifiedAssets) (solver : Pub
   in if
     | not (isTransferable token) := throw mkNonTransferableError
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
-    | else := ok 
-      mkTxWithExtraData@{
-        nk;
-        consumed := [token];
-        created := [mkSwapIntent@{want; receiver := myself; solver}]
-      };
+    | else := ok (
+        mkTxWithExtraData@{
+          nk;
+          consumed := [token];
+          created := [mkSwapIntent@{want; receiver := myself; solver}]
+        },
+        [removeFromLedger@{kind := anomaKind token; account := myself; cms := [commitment token]}]
+      );

--- a/Token/Transaction/Swap.juvix
+++ b/Token/Transaction/Swap.juvix
@@ -1,6 +1,7 @@
 module Token.Transaction.Swap;
 
 import Stdlib.Prelude open;
+import Data.Set as Set open using {Set};
 import Anoma open;
 import AnomaHelpers open;
 
@@ -17,7 +18,7 @@ import Token.Indexing open;
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner of the token.
 swap (self : KeyPair) (token : Resource) (want : QuantifiedAssets) (solver : PublicKey)
-: Result TokenError (Pair Transaction (List TokenAssignment)) :=
+: Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Swap/Solution.juvix
+++ b/Token/Transaction/Swap/Solution.juvix
@@ -15,7 +15,7 @@ module Solution;
       resources : Set Resource
     };
 
-  toTxData (self : KeyPair) (solution : Solution) : TxData (Set Commitment) :=
+  toTransaction (self : KeyPair) (solution : Solution) : Transaction :=
     mkTxWithExtraData@{
       nk := KeyPair.privKey self;
       consumed := [Solution.intent solution];

--- a/Token/Transaction/Swap/Solution.juvix
+++ b/Token/Transaction/Swap/Solution.juvix
@@ -5,12 +5,13 @@ import Data.Set as Set open using {Set};
 import Anoma open;
 import AnomaHelpers open;
 
+import Authorization.Check open;
 import Authorization.Message open;
+import Token.Error open;
 
 module Solution;
   type Solution :=
     mk {
-      owner : PublicKey;
       intent : Resource;
       resources : Set Resource
     };

--- a/Token/Transaction/Swap/Solution.juvix
+++ b/Token/Transaction/Swap/Solution.juvix
@@ -13,14 +13,14 @@ module Solution;
   type Solution :=
     mk {
       intent : Resource;
-      resources : Set Resource
+      created : Set Resource
     };
 
   toTransaction (self : KeyPair) (solution : Solution) : Transaction :=
     mkTxWithExtraData@{
       nk := KeyPair.privKey self;
       consumed := [Solution.intent solution];
-      created := Set.toList (Solution.resources solution)
+      created := Set.toList (Solution.created solution)
     };
 
   open Solution public;

--- a/Token/Transaction/Swap/Solution.juvix
+++ b/Token/Transaction/Swap/Solution.juvix
@@ -1,0 +1,28 @@
+module Token.Transaction.Swap.Solution;
+
+import Stdlib.Prelude open;
+import Data.Set as Set open using {Set};
+import Anoma open;
+import AnomaHelpers open;
+
+import Authorization.Message open;
+
+module Solution;
+  type Solution :=
+    mk {
+      owner : PublicKey;
+      intent : Resource;
+      resources : Set Resource
+    };
+
+  toTxData (self : KeyPair) (solution : Solution) : TxData (Set Commitment) :=
+    mkTxWithExtraData@{
+      nk := KeyPair.privKey self;
+      consumed := [Solution.intent solution];
+      created := Set.toList (Solution.resources solution)
+    };
+
+  open Solution public;
+end;
+
+open Solution using {Solution} public;

--- a/Token/Transaction/Transfer.juvix
+++ b/Token/Transaction/Transfer.juvix
@@ -16,10 +16,7 @@ import Token.Indexing open;
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner.
 transfer
-  (self : KeyPair)
-  (token : Resource)
-  (receiver : PublicKey)
-  : Result TokenError (TxData (Set Commitment)) :=
+  (self : KeyPair) (token : Resource) (receiver : PublicKey) : Result TokenError Transaction :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Transfer.juvix
+++ b/Token/Transaction/Transfer.juvix
@@ -14,7 +14,7 @@ import Token.Indexing open;
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner.
 transfer (self : KeyPair) (token : Resource) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
+: Result TokenError (Pair Transaction (List TokenAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Transfer.juvix
+++ b/Token/Transaction/Transfer.juvix
@@ -7,19 +7,27 @@ import Authorization.Check open;
 import Authorization.Message open;
 import Token.Label open;
 import Token.Error open;
+import Token.Indexing open;
 
 --- Transfers the token ;Resource; to a receiver, if the calling ;KeyPair; is the owner.
 --- The function returns a ;TokenError; if 
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner.
 transfer (self : KeyPair) (token : Resource) (receiver : PublicKey)
-: Result TokenError Transaction  :=
+: Result TokenError (Pair Transaction (List LedgerAssignment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
     newToken := token@Resource{npk := receiver};
+    kind : Kind := anomaKind token;
   in if
     | not (isTransferable token) := throw mkNonTransferableError
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
-    | else := ok mkTxWithExtraData@{nk; consumed := [token]; created := [newToken]};
+    | else := ok (
+      mkTxWithExtraData@{nk; consumed := [token]; created := [newToken]},
+      [
+        removeFromLedger@{kind; account := myself; cms := [commitment token]};
+        addToLedger@{kind; account := receiver; cms := [commitment newToken]}
+      ]
+    );

--- a/Token/Transaction/Transfer.juvix
+++ b/Token/Transaction/Transfer.juvix
@@ -1,6 +1,7 @@
 module Token.Transaction.Transfer;
 
 import Stdlib.Prelude open;
+import Data.Set as Set open using {Set};
 import Anoma open;
 
 import Authorization.Check open;
@@ -14,7 +15,7 @@ import Token.Indexing open;
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner.
 transfer (self : KeyPair) (token : Resource) (receiver : PublicKey)
-: Result TokenError (Pair Transaction (List TokenAssignment)) :=
+: Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;

--- a/Token/Transaction/Transfer.juvix
+++ b/Token/Transaction/Transfer.juvix
@@ -20,14 +20,7 @@ transfer (self : KeyPair) (token : Resource) (receiver : PublicKey)
     nk : PrivateKey := KeyPair.privKey self;
     owner : PublicKey := Resource.npk token;
     newToken := token@Resource{npk := receiver};
-    kind : Kind := anomaKind token;
   in if
     | not (isTransferable token) := throw mkNonTransferableError
     | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
-    | else := ok (
-      mkTxWithExtraData@{nk; consumed := [token]; created := [newToken]},
-      [
-        removeFromLedger@{kind; account := myself; cms := [commitment token]};
-        addToLedger@{kind; account := receiver; cms := [commitment newToken]}
-      ]
-    );
+    | else := ok mkTxWithExtraData@{nk; consumed := [token]; created := [newToken]};

--- a/Token/Transaction/Transfer.juvix
+++ b/Token/Transaction/Transfer.juvix
@@ -3,6 +3,7 @@ module Token.Transaction.Transfer;
 import Stdlib.Prelude open;
 import Data.Set as Set open using {Set};
 import Anoma open;
+import AnomaHelpers open;
 
 import Authorization.Check open;
 import Authorization.Message open;
@@ -11,11 +12,14 @@ import Token.Error open;
 import Token.Indexing open;
 
 --- Transfers the token ;Resource; to a receiver, if the calling ;KeyPair; is the owner.
---- The function returns a ;TokenError; if 
+--- The function returns a ;TokenError; if
 --- - the token is non-transferable
 --- - the calling ;KeyPair; is not the owner.
-transfer (self : KeyPair) (token : Resource) (receiver : PublicKey)
-: Result TokenError (TxData (Set Commitment)) :=
+transfer
+  (self : KeyPair)
+  (token : Resource)
+  (receiver : PublicKey)
+  : Result TokenError (TxData (Set Commitment)) :=
   let
     myself : PublicKey := KeyPair.pubKey self;
     nk : PrivateKey := KeyPair.privKey self;
@@ -23,5 +27,16 @@ transfer (self : KeyPair) (token : Resource) (receiver : PublicKey)
     newToken := token@Resource{npk := receiver};
   in if
     | not (isTransferable token) := throw mkNonTransferableError
-    | owner /= myself := throw mkUnauthorizedError@{expected := myself; actual := owner}
-    | else := ok mkTxWithExtraData@{nk; consumed := [token]; created := [newToken]};
+    | owner /= myself :=
+      throw
+        mkUnauthorizedError@{
+          expected := myself;
+          actual := owner
+        }
+    | else :=
+      ok
+        mkTxWithExtraData@{
+          nk;
+          consumed := [token];
+          created := [newToken]
+        };

--- a/index.juvix
+++ b/index.juvix
@@ -13,6 +13,7 @@ import Token.Projection;
 import Token.Resource;
 import Token.Supply;
 import Token.Transaction;
+import Token.Indexing;
 
 import Utils.Counter.Count;
 import Utils.Counter.Error;


### PR DESCRIPTION
This PR 
- resolves https://github.com/anoma/anoma-app-patterns/issues/18 by populating Anoma's KV-store
- allows a list of resources to be consumed for the `swap` function
- introduces a `settle` function for the swap
- formats the token transaction function code