### PR TITLE
refactor: improvements to handling of extra data

### DIFF
--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -202,10 +202,10 @@ commitmentSet (tx : Transaction) : Set Commitment := Set.fromList (Transaction.c
 
 nullifierSet (tx : Transaction) : Set Nullifier := Set.fromList (Transaction.nullifiers tx);
 
-lookupExtraData {Value : Type} (key : Bytes32) (tx : Transaction) : Maybe Value :=
+lookupExtraData {Key Value : Type} (key : Key) (tx : Transaction) : Maybe Value :=
   let
     keyValueMap : Map Bytes32 Bytes := anomaDecode (Transaction.extra tx);
-  in map (Bytes.unBytes >> anomaDecode) (Map.lookup key keyValueMap);
+  in map (Bytes.unBytes >> anomaDecode) (Map.lookup (anomaEncode key |> natToBytes32) keyValueMap);
 
 mkTransaction
   (nullifierKey : PrivateKey)

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -207,6 +207,9 @@ lookupExtraData {Key Value : Type} (key : Key) (tx : Transaction) : Maybe Value 
     keyValueMap : Map Bytes32 Bytes := anomaDecode (Transaction.extra tx);
   in map (Bytes.unBytes >> anomaDecode) (Map.lookup (anomaEncode key |> natToBytes32) keyValueMap);
 
+mkExtraDataEntry {Key Value : Type} : Pair Key Value -> Pair Bytes32 Bytes
+  | (key, value) := natToBytes32 (anomaEncode key) , natToBytes (anomaEncode value);
+
 mkTransaction
   (nullifierKey : PrivateKey)
   (consumed : List Resource)

--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -230,7 +230,7 @@ emptyTx : Transaction :=
     nullifiers := [];
     proofs := [];
     delta := [];
-    extra := 0;
+    extra := anomaEncode (Map.empty {Bytes32} {Bytes});
     preference := 0
   };
 

--- a/Authorization/Check.juvix
+++ b/Authorization/Check.juvix
@@ -12,7 +12,7 @@ isAuthorizedBy (signer : PublicKey) (self : Resource) (tx : Transaction) : Bool 
     cm := commitment self;
   in case
        lookupExtraData@{
-         key := natToBytes32 (anomaEncode cm);
+         key := cm;
          Value := Pair ResourceRelationship Signature;
          tx
        }

--- a/Authorization/Message.juvix
+++ b/Authorization/Message.juvix
@@ -32,9 +32,8 @@ mkResourceRelationshipExtraDataMapEntry
         mustBeConsumed := consumedNfs;
         mustBeCreated := createdCms
       };
-    k : Bytes32 := natToBytes32 (anomaEncode originCm);
-    v : Bytes := natToBytes (anomaEncode (msg, anomaSignDetached msg nullifierKey));
-  in k, v;
+    sig := anomaSignDetached msg nullifierKey;
+  in (originCm, (msg, sig)) |> mkExtraDataEntry;
 
 mkResourceRelationshipExtraData
   (nullifierKey : PrivateKey)

--- a/Utils/Counter/Extra.juvix
+++ b/Utils/Counter/Extra.juvix
@@ -14,7 +14,7 @@ findCreatedCounter (consumedCounter : Resource) (tx : Transaction) : Maybe Resou
     cm : Commitment := commitment consumedCounter;
   in case
        lookupExtraData@{
-         key := natToBytes32 (anomaEncode cm);
+         key := cm;
          Value := ResourceRelationship;
          tx
        }


### PR DESCRIPTION
* Change `lookupExtraData` to work with the key type, so the caller doesn't have to know how keys are encoded in the extra data map.
* Add `mkExtraDataEntry` as a function responsible for encoding key/values into an extra data map entry.
* Empty transaction extra data should be an empty map